### PR TITLE
Added missing Flamingo change to PacketCache.cpp

### DIFF
--- a/src/modules/Modules.cpp
+++ b/src/modules/Modules.cpp
@@ -341,16 +341,16 @@ void setupModules()
     externalNotificationModule = new ExternalNotificationModule();
 #endif
 
-// I've hacked this - random endifs etc to get a compile .
 #ifdef FLAMINGO
 #if !MESHTASTIC_EXCLUDE_RANGETEST
         if (moduleConfig.has_range_test && moduleConfig.range_test.enabled)
             new RangeTestModule();
 #endif
-#endif
+#else
 #if !MESHTASTIC_EXCLUDE_RANGETEST && !MESHTASTIC_EXCLUDE_GPS
     if (moduleConfig.has_range_test && moduleConfig.range_test.enabled)
         new RangeTestModule();
+#endif
 #endif
     // NOTE! This module must be added LAST because it likes to check for replies from other modules and avoid sending extra
     // acks


### PR DESCRIPTION
I found a missing change from the Flamingo 2.7.16 merge, it was in PacketCache.cpp.


## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [x] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
