### PR TITLE
put the forced pin def behind a switch

### DIFF
--- a/src/modules/BlinkModule.h
+++ b/src/modules/BlinkModule.h
@@ -8,10 +8,12 @@
 #include <Arduino.h>
 #include <functional>
 
+#ifdef FLAMINGO_BLINKY
 #ifndef FLAMINGO_BLINKY_IO
 #define BLINK_PIN 17
 #else
 #define BLINK_PIN FLAMINGO_BLINKY_IO
+#endif
 #endif
 
 #ifdef FLAMINGO_RT_LED


### PR DESCRIPTION
I kind of want to remove these forced definitions entirely, 
So just throw an error if it needs them, and they aren't provided at compile time. 
similar to what I did with the SLINK pins

``` cpp
#if defined(FLAMINGO) && defined(FLAMINGO_SLINK)

// Require pin definitions at compile time if not set in moduleConfig
#ifndef FLAMINGO_SLINK_RXD
#error "FLAMINGO_SLINK_RXD must be defined in platformio.ini build_flags (e.g., -DFLAMINGO_SLINK_RXD=15)"
#endif
#ifndef FLAMINGO_SLINK_TXD
#error "FLAMINGO_SLINK_TXD must be defined in platformio.ini build_flags (e.g., -DFLAMINGO_SLINK_TXD=16)"
#endif
```