### PR TITLE
Flamingo serialfix

### DIFF
--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -132,6 +132,46 @@ bool FloodingRouter::isRebroadcaster()
            config.device.rebroadcast_mode != meshtastic_Config_DeviceConfig_RebroadcastMode_NONE;
 }
 
+void FloodingRouter::perhapsRebroadcast(const meshtastic_MeshPacket *p)
+{
+    if (!isToUs(p) && (p->hop_limit > 0) && !isFromUs(p)) {
+        if (p->id != 0) {
+            if (isRebroadcaster()) {
+                meshtastic_MeshPacket *tosend = packetPool.allocCopy(*p); // keep a copy because we will be sending it
+
+                tosend->hop_limit--; // bump down the hop count
+#if USERPREFS_EVENT_MODE
+                if (tosend->hop_limit > 2) {
+                    // if we are "correcting" the hop_limit, "correct" the hop_start by the same amount to preserve hops away.
+                    tosend->hop_start -= (tosend->hop_limit - 2);
+                    tosend->hop_limit = 2;
+                }
+#endif
+                tosend->next_hop = NO_NEXT_HOP_PREFERENCE; // this should already be the case, but just in case
+
+                LOG_INFO("Rebroadcast received floodmsg");
+#ifdef FLAMINGO_MAX_REXMIT
+                // this method gets handed packets that have been seen recently and is a reliable router repeat
+                // do not add these to the retransmit queue, causes an infinite loop
+                bool isRepeated = p->hop_start > 0 && p->hop_start == p->hop_limit;
+                if (FLAMINGO_MAX_REXMIT > 0 && !isRepeated) {
+                    if ((!isFromUs(p) || !p->want_ack) && (p->hop_limit > 0 || p->want_ack)) {
+                        startRetransmission(packetPool.allocCopy(*p)); // start retransmission for relayed packet
+                    }
+                }
+#endif
+                // Note: we are careful to resend using the original senders node id
+                // We are careful not to call our hooked version of send() - because we don't want to check this again
+                Router::send(tosend);
+            } else {
+                LOG_DEBUG("No rebroadcast: Role = CLIENT_MUTE or Rebroadcast Mode = NONE");
+            }
+        } else {
+            LOG_DEBUG("Ignore 0 id broadcast");
+        }
+    }
+}
+
 void FloodingRouter::sniffReceived(const meshtastic_MeshPacket *p, const meshtastic_Routing *c)
 {
     bool isAckorReply = (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag) &&
@@ -147,3 +187,121 @@ void FloodingRouter::sniffReceived(const meshtastic_MeshPacket *p, const meshtas
     // handle the packet as normal
     Router::sniffReceived(p, c);
 }
+
+#ifdef FLAMINGO_MAX_REXMIT
+PendingPacket *FloodingRouter::startRetransmission(meshtastic_MeshPacket *p, uint8_t numReTx)
+{
+
+    auto id = GlobalPacketId(p);
+    auto rec = PendingPacket(p, numReTx);
+    LOG_DEBUG("FloodRtr::startRetran fr=0x%x,to=0x%x,id=0x%x, tries left=%d", p->from, p->to, p->id, numReTx);
+    stopRetransmission(getFrom(p), p->id);
+    setNextTx(&rec);
+    pending[id] = rec;
+
+    return &pending[id];
+}
+
+PendingPacket *FloodingRouter::findPendingPacket(GlobalPacketId key)
+{
+    auto old = pending.find(key); // If we have an old record, someone messed up because id got reused
+    if (old != pending.end()) {
+        return &old->second;
+    } else
+        return NULL;
+}
+
+/**
+ * Stop any retransmissions we are doing of the specified node/packet ID pair
+ */
+bool FloodingRouter::stopRetransmission(NodeNum from, PacketId id)
+{
+    auto key = GlobalPacketId(from, id);
+    return stopRetransmission(key);
+}
+
+bool FloodingRouter::stopRetransmission(GlobalPacketId key)
+{
+    auto old = findPendingPacket(key);
+    if (old) {
+        auto p = old->packet;
+        /* Only when we already transmitted a packet via LoRa, we will cancel the packet in the Tx queue
+          to avoid canceling a transmission if it was ACKed super fast via MQTT */
+        if (old->numRetransmissions < NUM_RELIABLE_RETX - 1) {
+            // We only cancel it if we are the original sender or if we're not a router(_late)/repeater
+            if (isFromUs(p) || (config.device.role != meshtastic_Config_DeviceConfig_Role_ROUTER &&
+                                config.device.role != meshtastic_Config_DeviceConfig_Role_REPEATER &&
+                                config.device.role != meshtastic_Config_DeviceConfig_Role_ROUTER_LATE)) {
+                // remove the 'original' (identified by originator and packet->id) from the txqueue and free it
+                cancelSending(getFrom(p), p->id);
+            }
+        }
+
+        // Regardless of whether or not we canceled this packet from the txQueue, remove it from our pending list so it doesn't
+        // get scheduled again. (This is the core of stopRetransmission.)
+        auto numErased = pending.erase(key);
+        assert(numErased == 1);
+
+        // When we remove an entry from pending, always be sure to release the copy of the packet that was allocated in the call
+        // to startRetransmission.
+        packetPool.release(p);
+
+        return true;
+    } else
+        return false;
+}
+
+/**
+ * Do any retransmissions that are scheduled (FIXME - for the time being called from loop)
+ */
+int32_t FloodingRouter::doRetransmissions()
+{
+    uint32_t now = millis();
+    int32_t d = INT32_MAX;
+    LOG_DEBUG("In FloodingRouter:doRetran");
+
+    // FIXME, we should use a better datastructure rather than walking through this map.
+    // for(auto el: pending) {
+    for (auto it = pending.begin(), nextIt = it; it != pending.end(); it = nextIt) {
+        ++nextIt; // we use this odd pattern because we might be deleting it...
+        auto &p = it->second;
+
+        bool stillValid = true; // assume we'll keep this record around
+
+        // FIXME, handle 51 day rolloever here!!!
+        if (p.nextTxMsec <= now) {
+            if (p.numRetransmissions == 0) {
+                // Note: we don't stop retransmission here, instead the Nak packet gets processed in sniffReceived
+                stopRetransmission(it->first);
+                stillValid = false; // just deleted it
+            } else {
+                LOG_DEBUG("Sending retransmission fr=0x%x,to=0x%x,id=0x%x, tries left=%d", p.packet->from, p.packet->to,
+                          p.packet->id, p.numRetransmissions);
+                Router::send(packetPool.allocCopy(*p.packet));
+                // Queue again
+                --p.numRetransmissions;
+                setNextTx(&p);
+            }
+        }
+
+        if (stillValid) {
+            // Update our desired sleep delay
+            int32_t t = p.nextTxMsec - now;
+
+            d = min(t, d);
+        }
+    }
+
+    return d;
+}
+
+void FloodingRouter::setNextTx(PendingPacket *pending)
+{
+    assert(iface);
+    auto d = iface->getRetransmissionMsec(pending->packet);
+    pending->nextTxMsec = millis() + d;
+    LOG_DEBUG("Setting next retransmission in %u msecs: ", d);
+    setReceivedMessage(); // Run ASAP, so we can figure out our correct sleep time
+}
+
+#endif

--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -151,13 +151,12 @@ void FloodingRouter::perhapsRebroadcast(const meshtastic_MeshPacket *p)
                 tosend->next_hop = NO_NEXT_HOP_PREFERENCE; // this should already be the case, but just in case
 
                 LOG_INFO("Rebroadcast received floodmsg");
-
-                // this method gets handed packets that have been seen recently and is a reliable router repeat
-                // do not add these to the retransmit queue, causes an infinite loop
-                bool isRepeated = p->hop_start > 0 && p->hop_start == p->hop_limit;
-                if (FLAMINGO_MAX_REXMIT > 0 && !isRepeated) {
+                if (FLAMINGO_MAX_REXMIT > 0) {
                     if ((!isFromUs(p) || !p->want_ack) &&  (p->hop_limit > 0 || p->want_ack)) {
-                        startRetransmission(packetPool.allocCopy(*p)); // start retransmission for relayed packet
+                        meshtastic_MeshPacket *toxmit = packetPool.allocCopy(*p);
+                        toxmit->hop_limit--; // bump down the hop count
+                        toxmit->next_hop = NO_NEXT_HOP_PREFERENCE;
+                        startRetransmission(toxmit); // start retransmission for relayed packet
                     }
                 }
 

--- a/src/mesh/FloodingRouter.cpp
+++ b/src/mesh/FloodingRouter.cpp
@@ -132,6 +132,7 @@ bool FloodingRouter::isRebroadcaster()
            config.device.rebroadcast_mode != meshtastic_Config_DeviceConfig_RebroadcastMode_NONE;
 }
 
+#ifdef FLAMINGO_MAX_REXMIT
 void FloodingRouter::perhapsRebroadcast(const meshtastic_MeshPacket *p)
 {
     if (!isToUs(p) && (p->hop_limit > 0) && !isFromUs(p)) {
@@ -150,16 +151,16 @@ void FloodingRouter::perhapsRebroadcast(const meshtastic_MeshPacket *p)
                 tosend->next_hop = NO_NEXT_HOP_PREFERENCE; // this should already be the case, but just in case
 
                 LOG_INFO("Rebroadcast received floodmsg");
-#ifdef FLAMINGO_MAX_REXMIT
+
                 // this method gets handed packets that have been seen recently and is a reliable router repeat
                 // do not add these to the retransmit queue, causes an infinite loop
                 bool isRepeated = p->hop_start > 0 && p->hop_start == p->hop_limit;
                 if (FLAMINGO_MAX_REXMIT > 0 && !isRepeated) {
-                    if ((!isFromUs(p) || !p->want_ack) && (p->hop_limit > 0 || p->want_ack)) {
+                    if ((!isFromUs(p) || !p->want_ack) &&  (p->hop_limit > 0 || p->want_ack)) {
                         startRetransmission(packetPool.allocCopy(*p)); // start retransmission for relayed packet
                     }
                 }
-#endif
+
                 // Note: we are careful to resend using the original senders node id
                 // We are careful not to call our hooked version of send() - because we don't want to check this again
                 Router::send(tosend);
@@ -171,6 +172,7 @@ void FloodingRouter::perhapsRebroadcast(const meshtastic_MeshPacket *p)
         }
     }
 }
+#endif
 
 void FloodingRouter::sniffReceived(const meshtastic_MeshPacket *p, const meshtastic_Routing *c)
 {

--- a/src/mesh/FloodingRouter.h
+++ b/src/mesh/FloodingRouter.h
@@ -2,6 +2,54 @@
 
 #include "Router.h"
 
+#ifdef FLAMINGO_MAX_REXMIT
+/**
+ * An identifier for a globally unique message - a pair of the sending nodenum and the packet id assigned
+ * to that message
+ */
+struct GlobalPacketId {
+    NodeNum node;
+    PacketId id;
+
+    bool operator==(const GlobalPacketId &p) const { return node == p.node && id == p.id; }
+
+    explicit GlobalPacketId(const meshtastic_MeshPacket *p)
+    {
+        node = getFrom(p);
+        id = p->id;
+    }
+
+    GlobalPacketId(NodeNum _from, PacketId _id)
+    {
+        node = _from;
+        id = _id;
+    }
+};
+
+/**
+ * A packet queued for retransmission
+ */
+struct PendingPacket {
+    meshtastic_MeshPacket *packet;
+
+    /** The next time we should try to retransmit this packet */
+    uint32_t nextTxMsec = 0;
+
+    /** Starts at NUM_RETRANSMISSIONS -1 and counts down.  Once zero it will be removed from the list */
+    uint8_t numRetransmissions = 0;
+
+    PendingPacket() {}
+    explicit PendingPacket(meshtastic_MeshPacket *p, uint8_t numRetransmissions);
+};
+
+class GlobalPacketIdHashFunction
+{
+  public:
+    size_t operator()(const GlobalPacketId &p) const { return (std::hash<NodeNum>()(p.node)) ^ (std::hash<PacketId>()(p.id)); }
+};
+
+#endif
+
 /**
  * This is a mixin that extends Router with the ability to do Naive Flooding (in the standard mesh protocol sense)
  *
@@ -41,6 +89,25 @@ class FloodingRouter : public Router
      */
     virtual ErrorCode send(meshtastic_MeshPacket *p) override;
 
+#ifdef FLAMINGO_MAX_REXMIT
+    /** Do our retransmission handling */
+    virtual int32_t runOnce() override
+    {
+        // Note: We must doRetransmissions FIRST, because it might queue up work for the base class runOnce implementation
+        doRetransmissions();
+
+        int32_t r = Router::runOnce();
+
+        // Also after calling runOnce there might be new packets to retransmit
+        auto d = doRetransmissions();
+        return min(d, r);
+    }
+
+    constexpr static uint8_t NUM_INTERMEDIATE_RETX = FLAMINGO_MAX_REXMIT + 1;
+    // The number of retransmissions the original sender will do
+    constexpr static uint8_t NUM_RELIABLE_RETX = 3;
+#endif
+
   protected:
     /**
      * Should this incoming filter be dropped?
@@ -75,4 +142,38 @@ class FloodingRouter : public Router
 
     // Return true if we are a rebroadcaster
     bool isRebroadcaster();
+#ifdef FLAMINGO_MAX_REXMIT
+
+    /**
+     * Pending retransmissions
+     */
+    std::unordered_map<GlobalPacketId, PendingPacket, GlobalPacketIdHashFunction> pending;
+
+    /**
+     * Try to find the pending packet record for this ID (or NULL if not found)
+     */
+    PendingPacket *findPendingPacket(NodeNum from, PacketId id) { return findPendingPacket(GlobalPacketId(from, id)); }
+    PendingPacket *findPendingPacket(GlobalPacketId p);
+
+    /**
+     * Add p to the list of packets to retransmit occasionally.  We will free it once we stop retransmitting.
+     */
+    PendingPacket *startRetransmission(meshtastic_MeshPacket *p, uint8_t numReTx = NUM_INTERMEDIATE_RETX);
+
+    /**
+     * Stop any retransmissions we are doing of the specified node/packet ID pair
+     *
+     * @return true if we found and removed a transmission with this ID
+     */
+    bool stopRetransmission(NodeNum from, PacketId id);
+    bool stopRetransmission(GlobalPacketId p);
+    /**
+     * Do any retransmissions that are scheduled (FIXME - for the time being called from loop)
+     *
+     * @return the number of msecs until our next retransmission or MAXINT if none scheduled
+     */
+    int32_t doRetransmissions();
+
+    void setNextTx(PendingPacket *pending);
+#endif
 };

--- a/src/mesh/FloodingRouter.h
+++ b/src/mesh/FloodingRouter.h
@@ -106,6 +106,10 @@ class FloodingRouter : public Router
     constexpr static uint8_t NUM_INTERMEDIATE_RETX = FLAMINGO_MAX_REXMIT + 1;
     // The number of retransmissions the original sender will do
     constexpr static uint8_t NUM_RELIABLE_RETX = 3;
+
+private:
+    /* Check if we should rebroadcast this packet, and do so if needed */
+    void perhapsRebroadcast(const meshtastic_MeshPacket *p);
 #endif
 
   protected:
@@ -122,8 +126,11 @@ class FloodingRouter : public Router
      */
     virtual void sniffReceived(const meshtastic_MeshPacket *p, const meshtastic_Routing *c) override;
 
+#ifndef FLAMINGO_MAX_REXMIT
     /* Check if we should rebroadcast this packet, and do so if needed */
     virtual bool perhapsRebroadcast(const meshtastic_MeshPacket *p) = 0;
+#endif
+
 
     /* Check if we should handle an upgraded packet (with higher hop_limit)
      * @return true if we handled it (so stop processing)

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -28,8 +28,16 @@ ErrorCode NextHopRouter::send(meshtastic_MeshPacket *p)
 
     // If it's from us, ReliableRouter already handles retransmissions if want_ack is set. If a next hop is set and hop limit is
     // not 0 or want_ack is set, start retransmissions
-    if ((!isFromUs(p) || !p->want_ack) && p->next_hop != NO_NEXT_HOP_PREFERENCE && (p->hop_limit > 0 || p->want_ack))
+    #ifdef FLAMINGO
+    // Don't check for known next hop
+    if ((!isFromUs(p) || !p->want_ack) &&  (p->hop_limit > 0 || p->want_ack)) {
         startRetransmission(packetPool.allocCopy(*p)); // start retransmission for relayed packet
+    }
+#else
+    if ((!isFromUs(p) || !p->want_ack) && p->next_hop != NO_NEXT_HOP_PREFERENCE && (p->hop_limit > 0 || p->want_ack)) {
+        startRetransmission(packetPool.allocCopy(*p)); // start retransmission for relayed packet
+    }
+#endif
 
     return Router::send(p);
 }

--- a/src/mesh/NextHopRouter.cpp
+++ b/src/mesh/NextHopRouter.cpp
@@ -28,10 +28,12 @@ ErrorCode NextHopRouter::send(meshtastic_MeshPacket *p)
 
     // If it's from us, ReliableRouter already handles retransmissions if want_ack is set. If a next hop is set and hop limit is
     // not 0 or want_ack is set, start retransmissions
-    #ifdef FLAMINGO
-    // Don't check for known next hop
-    if ((!isFromUs(p) || !p->want_ack) &&  (p->hop_limit > 0 || p->want_ack)) {
-        startRetransmission(packetPool.allocCopy(*p)); // start retransmission for relayed packet
+#ifdef FLAMINGO_MAX_REXMIT
+    // Don't check for known next hop and only rxmit if max_rexmit > 0
+    if (FLAMINGO_MAX_REXMIT > 0) {
+        if ((!isFromUs(p) || !p->want_ack) && (p->hop_limit > 0 || p->want_ack)) {
+            startRetransmission(packetPool.allocCopy(*p)); // start retransmission for relayed packet
+        }
     }
 #else
     if ((!isFromUs(p) || !p->want_ack) && p->next_hop != NO_NEXT_HOP_PREFERENCE && (p->hop_limit > 0 || p->want_ack)) {

--- a/src/mesh/NextHopRouter.h
+++ b/src/mesh/NextHopRouter.h
@@ -3,6 +3,7 @@
 #include "FloodingRouter.h"
 #include <unordered_map>
 
+#ifndef FLAMINGO_MAX_REXMIT
 /**
  * An identifier for a globally unique message - a pair of the sending nodenum and the packet id assigned
  * to that message
@@ -48,6 +49,8 @@ class GlobalPacketIdHashFunction
     size_t operator()(const GlobalPacketId &p) const { return (std::hash<NodeNum>()(p.node)) ^ (std::hash<PacketId>()(p.id)); }
 };
 
+#endif
+
 /*
   Router for direct messages, which only relays if it is the next hop for a packet. The next hop is set by the current
   relayer of a packet, which bases this on information from a previous successful delivery to the destination via flooding.
@@ -87,7 +90,11 @@ class NextHopRouter : public FloodingRouter
     }
 
     // The number of retransmissions intermediate nodes will do (actually 1 less than this)
-    constexpr static uint8_t NUM_INTERMEDIATE_RETX = 2;
+#ifdef FLAMINGO_MAX_REXMIT
+    constexpr static uint8_t NUM_INTERMEDIATE_RETX = FLAMINGO_MAX_REXMIT + 1;
+#else
+    constexpr static uint8_t NUM_INTERMEDIATE_RETX = 3;
+#endif
     // The number of retransmissions the original sender will do
     constexpr static uint8_t NUM_RELIABLE_RETX = 3;
 

--- a/src/mesh/NextHopRouter.h
+++ b/src/mesh/NextHopRouter.h
@@ -157,5 +157,9 @@ class NextHopRouter : public FloodingRouter
 
     /** Check if we should be rebroadcasting this packet if so, do so.
      *  @return true if we did rebroadcast */
+#ifdef FLAMINGO_MAX_REXMIT
+    bool perhapsRebroadcast(const meshtastic_MeshPacket *p);
+#else
     bool perhapsRebroadcast(const meshtastic_MeshPacket *p) override;
+#endif
 };

--- a/src/mesh/NodeDB.cpp
+++ b/src/mesh/NodeDB.cpp
@@ -149,6 +149,33 @@ uint32_t get_st7789_id(uint8_t cs, uint8_t sck, uint8_t mosi, uint8_t dc, uint8_
 
 #endif
 
+#ifdef FLAMINGO_HOP_DEBUG
+void get_shortname_from_id(uint32_t id, char *namebuf) {
+    if (id == 0xffffffff) {
+        strncpy(namebuf,"BCST",4);
+    } else {
+        auto node = nodeDB->getMeshNode(id);
+        (node) ? strncpy(namebuf, node->user.short_name, 4) : strncpy(namebuf,"????",4);
+    }
+    namebuf[4] = 0;
+}
+
+uint16_t get_myshortname_magicnumber() {
+
+    uint16_t retval = 0;
+    auto node = nodeDB->getMeshNode(myNodeInfo.my_node_num);
+    const char *sender = (node) ? node->user.short_name : "????";
+
+    if ( sender[2] >= 0x30 && sender[2]  <= 0x39) {
+        retval = (sender[2] - 0x30) * 10;
+    }
+    if ( sender[3] >= 0x30 && sender[3]  <= 0x39) {
+        retval += (sender[3] - 0x30);
+    }
+    return retval;
+}
+#endif
+
 bool meshtastic_NodeDatabase_callback(pb_istream_t *istream, pb_ostream_t *ostream, const pb_field_iter_t *field)
 {
     if (ostream) {

--- a/src/mesh/NodeDB.h
+++ b/src/mesh/NodeDB.h
@@ -95,6 +95,11 @@ extern meshtastic_LocalModuleConfig moduleConfig;
 extern meshtastic_User &owner;
 extern meshtastic_Position localPosition;
 
+#ifdef FLAMINGO_HOP_DEBUG
+extern uint16_t get_myshortname_magicnumber();
+extern void get_shortname_from_id(uint32_t id, char *namebuf);
+#endif
+
 static constexpr const char *deviceStateFileName = "/prefs/device.proto";
 static constexpr const char *legacyPrefFileName = "/prefs/db.proto";
 static constexpr const char *nodeDatabaseFileName = "/prefs/nodes.proto";

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -245,8 +245,9 @@ uint32_t RadioInterface::getPacketTime(const meshtastic_MeshPacket *p, bool rece
 /** The delay to use for retransmitting dropped packets */
 uint32_t RadioInterface::getRetransmissionMsec(const meshtastic_MeshPacket *p)
 {
-    size_t numbytes =p->which_payload_variant == meshtastic_MeshPacket_decoded_tag ? 
-      pb_encode_to_bytes(bytes, sizeof(bytes), &meshtastic_Data_msg, &p->decoded) : p->encrypted.size+MESHTASTIC_HEADER_LENGTH;
+    size_t numbytes = p->which_payload_variant == meshtastic_MeshPacket_decoded_tag
+                          ? pb_encode_to_bytes(bytes, sizeof(bytes), &meshtastic_Data_msg, &p->decoded)
+                          : p->encrypted.size;
     uint32_t packetAirtime = getPacketTime(numbytes + sizeof(PacketHeader));
     // Make sure enough time has elapsed for this packet to be sent and an ACK is received.
     // LOG_DEBUG("Waiting for flooding message with airtime %d and slotTime is %d", packetAirtime, slotTimeMsec);
@@ -387,7 +388,7 @@ void printPacket(const char *prefix, const meshtastic_MeshPacket *p)
 RadioInterface::RadioInterface()
 {
 #ifdef FLAMINGO
-    //assert(sizeof(PacketHeader) == MESHTASTIC_HEADER_LENGTH); // make sure the compiler did what we expected
+    // assert(sizeof(PacketHeader) == MESHTASTIC_HEADER_LENGTH); // make sure the compiler did what we expected
 #else
     assert(sizeof(PacketHeader) == MESHTASTIC_HEADER_LENGTH); // make sure the compiler did what we expected
 #endif
@@ -694,7 +695,8 @@ size_t RadioInterface::beginSending(meshtastic_MeshPacket *p)
 
     // LOG_DEBUG("Send queued packet on mesh (txGood=%d,rxGood=%d,rxBad=%d)", rf95.txGood(), rf95.rxGood(), rf95.rxBad());
     assert(p->which_payload_variant == meshtastic_MeshPacket_encrypted_tag); // It should have already been encoded by now
-    LOG_DEBUG("TX packet: from=0x%08x,to=0x%08x,id=0x%08x,Ch=0x%x, HopStart=%d, HopLim=%d", p->from, p->to, p->id, p->channel, p->hop_start, p->hop_limit);
+    LOG_DEBUG("TX packet: from=0x%08x,to=0x%08x,id=0x%08x,Ch=0x%x, HopStart=%d, HopLim=%d", p->from, p->to, p->id, p->channel,
+              p->hop_start, p->hop_limit);
 
     radioBuffer.header.from = p->from;
     radioBuffer.header.to = p->to;

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -245,7 +245,8 @@ uint32_t RadioInterface::getPacketTime(const meshtastic_MeshPacket *p, bool rece
 /** The delay to use for retransmitting dropped packets */
 uint32_t RadioInterface::getRetransmissionMsec(const meshtastic_MeshPacket *p)
 {
-    size_t numbytes = pb_encode_to_bytes(bytes, sizeof(bytes), &meshtastic_Data_msg, &p->decoded);
+    size_t numbytes =p->which_payload_variant == meshtastic_MeshPacket_decoded_tag ? 
+      pb_encode_to_bytes(bytes, sizeof(bytes), &meshtastic_Data_msg, &p->decoded) : p->encrypted.size+MESHTASTIC_HEADER_LENGTH;
     uint32_t packetAirtime = getPacketTime(numbytes + sizeof(PacketHeader));
     // Make sure enough time has elapsed for this packet to be sent and an ACK is received.
     // LOG_DEBUG("Waiting for flooding message with airtime %d and slotTime is %d", packetAirtime, slotTimeMsec);

--- a/src/mesh/RadioInterface.cpp
+++ b/src/mesh/RadioInterface.cpp
@@ -715,7 +715,13 @@ size_t RadioInterface::beginSending(meshtastic_MeshPacket *p)
 
     radioBuffer.header.hop_limit = p->hop_limit & PACKET_FLAGS_HOP_LIMIT_MASK;
     radioBuffer.header.hop_start = p->hop_start & PACKET_FLAGS_HOP_START_MASK;
+#ifdef FLAMINGO_HOP_DEBUG
+    //highjack magic number to identify sender of this packet
+    radioBuffer.header.magicnum = get_myshortname_magicnumber();
+    LOG_DEBUG("TX packet: from=0x%08x,to=0x%08x,id=0x%08x,Ch=0x%x, HopStart=%d, HopLim=%d, MagicNum:%d", p->from, p->to, p->id, p->channel, p->hop_start, p->hop_limit, radioBuffer.header.magicnum);
+#else
     radioBuffer.header.magicnum = PACKET_HEADER_MAGIC_NUMBER;
+#endif
 #else
     radioBuffer.header.flags =
         p->hop_limit | (p->want_ack ? PACKET_FLAGS_WANT_ACK_MASK : 0) | (p->via_mqtt ? PACKET_FLAGS_VIA_MQTT_MASK : 0);

--- a/src/mesh/Router.cpp
+++ b/src/mesh/Router.cpp
@@ -379,7 +379,7 @@ ErrorCode Router::send(meshtastic_MeshPacket *p)
     }
 #ifdef FLAMINGO_SLINK
     if (moduleConfig.serial.enabled) {
-        serialModuleRadio->onSend(*p);
+        serialModuleRadio->onSend(p);
     }
 #endif
 #if HAS_UDP_MULTICAST

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -915,10 +915,7 @@ typedef struct _meshtastic_MeshPacket {
     meshtastic_MeshPacket_Delayed delayed;
     /* Describes whether this packet passed via MQTT somewhere along the path it currently took. */
     bool via_mqtt;
-#ifdef FLAMINGO
-    /* Describes whether this packet passed via the serial link somewhere along the path it currently took. */
-    bool via_slink;
-#endif
+
     /* Hop limit with which the original packet started. Sent via LoRa using three bits in the unencrypted header.
  When receiving a packet, the difference between hop_start and hop_limit gives how many hops it traveled. */
     uint8_t hop_start;
@@ -938,6 +935,10 @@ typedef struct _meshtastic_MeshPacket {
     uint32_t tx_after;
     /* Indicates which transport mechanism this packet arrived over */
     meshtastic_MeshPacket_TransportMechanism transport_mechanism;
+#ifdef FLAMINGO
+    /* Describes whether this packet passed via the serial link somewhere along the path it currently took. */
+    bool via_slink;
+#endif
 } meshtastic_MeshPacket;
 
 /* The bluetooth to device link:
@@ -1411,7 +1412,11 @@ extern "C" {
 #define meshtastic_KeyVerification_init_default  {0, {0, {0}}, {0, {0}}}
 #define meshtastic_Waypoint_init_default         {0, false, 0, false, 0, 0, 0, "", "", 0}
 #define meshtastic_MqttClientProxyMessage_init_default {"", 0, {{0, {0}}}, 0}
+#ifdef FLAMINGO
+#define meshtastic_MeshPacket_init_default       {0, 0, 0, 0, {meshtastic_Data_init_default}, 0, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN, 0}
+#else
 #define meshtastic_MeshPacket_init_default       {0, 0, 0, 0, {meshtastic_Data_init_default}, 0, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN}
+#endif
 #define meshtastic_NodeInfo_init_default         {0, false, meshtastic_User_init_default, false, meshtastic_Position_init_default, 0, 0, false, meshtastic_DeviceMetrics_init_default, 0, 0, false, 0, 0, 0, 0}
 #define meshtastic_MyNodeInfo_init_default       {0, 0, 0, {0, {0}}, "", _meshtastic_FirmwareEdition_MIN, 0}
 #define meshtastic_LogRecord_init_default        {"", 0, "", _meshtastic_LogRecord_Level_MIN}
@@ -1446,7 +1451,11 @@ extern "C" {
 #define meshtastic_KeyVerification_init_zero     {0, {0, {0}}, {0, {0}}}
 #define meshtastic_Waypoint_init_zero            {0, false, 0, false, 0, 0, 0, "", "", 0}
 #define meshtastic_MqttClientProxyMessage_init_zero {"", 0, {{0, {0}}}, 0}
+#ifdef FLAMINGO
+#define meshtastic_MeshPacket_init_zero          {0, 0, 0, 0, {meshtastic_Data_init_zero}, 0, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN, 0}
+#else
 #define meshtastic_MeshPacket_init_zero          {0, 0, 0, 0, {meshtastic_Data_init_zero}, 0, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN}
+#endif
 #define meshtastic_NodeInfo_init_zero            {0, false, meshtastic_User_init_zero, false, meshtastic_Position_init_zero, 0, 0, false, meshtastic_DeviceMetrics_init_zero, 0, 0, false, 0, 0, 0, 0}
 #define meshtastic_MyNodeInfo_init_zero          {0, 0, 0, {0, {0}}, "", _meshtastic_FirmwareEdition_MIN, 0}
 #define meshtastic_LogRecord_init_zero           {"", 0, "", _meshtastic_LogRecord_Level_MIN}
@@ -1555,6 +1564,7 @@ extern "C" {
 #define meshtastic_MeshPacket_relay_node_tag     19
 #define meshtastic_MeshPacket_tx_after_tag       20
 #define meshtastic_MeshPacket_transport_mechanism_tag 21
+#define meshtastic_MeshPacket_via_slink_tag      22
 #define meshtastic_NodeInfo_num_tag              1
 #define meshtastic_NodeInfo_user_tag             2
 #define meshtastic_NodeInfo_position_tag         3
@@ -2095,7 +2105,7 @@ extern const pb_msgdesc_t meshtastic_ChunkedPayloadResponse_msg;
 #define meshtastic_KeyVerification_size          79
 #define meshtastic_LogRecord_size                426
 #define meshtastic_LowEntropyKey_size            0
-#define meshtastic_MeshPacket_size               381
+#define meshtastic_MeshPacket_size               384
 #define meshtastic_MqttClientProxyMessage_size   501
 #define meshtastic_MyNodeInfo_size               83
 #define meshtastic_NeighborInfo_size             258

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -1552,7 +1552,6 @@ extern "C" {
 #define meshtastic_MeshPacket_relay_node_tag     19
 #define meshtastic_MeshPacket_tx_after_tag       20
 #define meshtastic_MeshPacket_transport_mechanism_tag 21
-#define meshtastic_MeshPacket_via_slink_tag      22
 #define meshtastic_NodeInfo_num_tag              1
 #define meshtastic_NodeInfo_user_tag             2
 #define meshtastic_NodeInfo_position_tag         3

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -935,10 +935,6 @@ typedef struct _meshtastic_MeshPacket {
     uint32_t tx_after;
     /* Indicates which transport mechanism this packet arrived over */
     meshtastic_MeshPacket_TransportMechanism transport_mechanism;
-#ifdef FLAMINGO
-    /* Describes whether this packet passed via the serial link somewhere along the path it currently took. */
-    bool via_slink;
-#endif
 } meshtastic_MeshPacket;
 
 /* The bluetooth to device link:
@@ -1412,11 +1408,7 @@ extern "C" {
 #define meshtastic_KeyVerification_init_default  {0, {0, {0}}, {0, {0}}}
 #define meshtastic_Waypoint_init_default         {0, false, 0, false, 0, 0, 0, "", "", 0}
 #define meshtastic_MqttClientProxyMessage_init_default {"", 0, {{0, {0}}}, 0}
-#ifdef FLAMINGO
-#define meshtastic_MeshPacket_init_default       {0, 0, 0, 0, {meshtastic_Data_init_default}, 0, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN, 0}
-#else
 #define meshtastic_MeshPacket_init_default       {0, 0, 0, 0, {meshtastic_Data_init_default}, 0, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN}
-#endif
 #define meshtastic_NodeInfo_init_default         {0, false, meshtastic_User_init_default, false, meshtastic_Position_init_default, 0, 0, false, meshtastic_DeviceMetrics_init_default, 0, 0, false, 0, 0, 0, 0}
 #define meshtastic_MyNodeInfo_init_default       {0, 0, 0, {0, {0}}, "", _meshtastic_FirmwareEdition_MIN, 0}
 #define meshtastic_LogRecord_init_default        {"", 0, "", _meshtastic_LogRecord_Level_MIN}
@@ -1451,11 +1443,7 @@ extern "C" {
 #define meshtastic_KeyVerification_init_zero     {0, {0, {0}}, {0, {0}}}
 #define meshtastic_Waypoint_init_zero            {0, false, 0, false, 0, 0, 0, "", "", 0}
 #define meshtastic_MqttClientProxyMessage_init_zero {"", 0, {{0, {0}}}, 0}
-#ifdef FLAMINGO
-#define meshtastic_MeshPacket_init_zero          {0, 0, 0, 0, {meshtastic_Data_init_zero}, 0, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN, 0}
-#else
 #define meshtastic_MeshPacket_init_zero          {0, 0, 0, 0, {meshtastic_Data_init_zero}, 0, 0, 0, 0, 0, _meshtastic_MeshPacket_Priority_MIN, 0, _meshtastic_MeshPacket_Delayed_MIN, 0, 0, {0, {0}}, 0, 0, 0, 0, _meshtastic_MeshPacket_TransportMechanism_MIN}
-#endif
 #define meshtastic_NodeInfo_init_zero            {0, false, meshtastic_User_init_zero, false, meshtastic_Position_init_zero, 0, 0, false, meshtastic_DeviceMetrics_init_zero, 0, 0, false, 0, 0, 0, 0}
 #define meshtastic_MyNodeInfo_init_zero          {0, 0, 0, {0, {0}}, "", _meshtastic_FirmwareEdition_MIN, 0}
 #define meshtastic_LogRecord_init_zero           {"", 0, "", _meshtastic_LogRecord_Level_MIN}
@@ -2105,7 +2093,7 @@ extern const pb_msgdesc_t meshtastic_ChunkedPayloadResponse_msg;
 #define meshtastic_KeyVerification_size          79
 #define meshtastic_LogRecord_size                426
 #define meshtastic_LowEntropyKey_size            0
-#define meshtastic_MeshPacket_size               384
+#define meshtastic_MeshPacket_size               381
 #define meshtastic_MqttClientProxyMessage_size   501
 #define meshtastic_MyNodeInfo_size               83
 #define meshtastic_NeighborInfo_size             258

--- a/src/mesh/generated/meshtastic/mesh.pb.h
+++ b/src/mesh/generated/meshtastic/mesh.pb.h
@@ -915,10 +915,6 @@ typedef struct _meshtastic_MeshPacket {
     meshtastic_MeshPacket_Delayed delayed;
     /* Describes whether this packet passed via MQTT somewhere along the path it currently took. */
     bool via_mqtt;
-#ifdef FLAMINGO
-    /* Describes whether this packet passed via the serial link somewhere along the path it currently took. */
-    bool via_slink;
-#endif
     /* Hop limit with which the original packet started. Sent via LoRa using three bits in the unencrypted header.
  When receiving a packet, the difference between hop_start and hop_limit gives how many hops it traveled. */
     uint8_t hop_start;

--- a/src/modules/RangeTestModule.cpp
+++ b/src/modules/RangeTestModule.cpp
@@ -126,8 +126,15 @@ int32_t RangeTestModule::runOnce()
             if (moduleConfig.range_test.sender) {
 #ifdef FLAMINGO
                 if (!getRtDynanmicEnable()) {
-                    LOG_INFO("Range Test Module is soft-disabled."); 
+                    LOG_INFO("Range Test Module is soft-disabled.");
+                    lastRtEnable = 0;
                     return (senderHeartbeat);
+                }
+
+                if (lastRtEnable != getRtDynanmicEnable()){
+                    // reset start time
+                    started = millis();
+                    lastRtEnable = getRtDynanmicEnable();
                 }
 #endif
                 // If sender

--- a/src/modules/RangeTestModule.cpp
+++ b/src/modules/RangeTestModule.cpp
@@ -38,7 +38,7 @@ uint32_t packetSequence = 0;
 #ifdef FLAMINGO
 
 #define SNR_BUFFER_SIZE 3    // 3 packets seem to be enough for a decent average
-#define SNR_MININMUM 1.0     // send three beeps if below this threadhold
+#define SNR_MINIMUM 3.0     // send three beeps if below this threadhold
 
 float snr_buffer[SNR_BUFFER_SIZE];  // SNR values of last SNR_BUFFER_SIZE packets
 float snr_last_average = 0.0;      // SNR average of last SNR_BUFFER_SIZE packets
@@ -240,7 +240,7 @@ ProcessMessage RangeTestModuleRadio::handleReceived(const meshtastic_MeshPacket 
             snr_buffer_ptr++;
             if (snr_buffer_ptr >= SNR_BUFFER_SIZE) snr_buffer_ptr = 0; // wrap pointer
             uint8_t num_tones = 1;
-            if ((snr_buffer_count == SNR_BUFFER_SIZE) && snr_last_average < SNR_MININMUM) {
+            if ((snr_buffer_count == SNR_BUFFER_SIZE) && snr_last_average < SNR_MINIMUM) {
                  num_tones = 3; // set max tones regardless of RSSI value
             }
             else if (mp.rx_rssi < -110) {

--- a/src/modules/RangeTestModule.h
+++ b/src/modules/RangeTestModule.h
@@ -15,6 +15,9 @@ class RangeTestModule : private concurrency::OSThread
 {
     bool firstTime = 1;
     unsigned long started = 0;
+#ifdef FLAMINGO
+    uint8_t lastRtEnable = 0;
+#endif 
 
   public:
     RangeTestModule();

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -16,12 +16,13 @@
     This module has been totally rewritten to function as a serial 'interface'
     for the router to send packets over the serial link similar to the MQTT interface.
 
-
     The serial link is simply an alternate path for packets other than the air.
 
     This is not a module, it does not source new packets or sink packets
 
     This is intended for the WisMesh starter kit (19007 board+ 4630) + RS485 which uses Serial1
+
+    This module will wait not transmit over the link if the RX is currently busy.
 
 */
 
@@ -40,7 +41,6 @@ SerialModuleRadio *serialModuleRadio;
 meshtastic_serialPacket outPacket;
 meshtastic_serialPacket inPacket;
 char tmpbuf[250]; // for debug only
-char tmpbuf[250]; // for debug only
 
 SerialModule::SerialModule() : StreamAPI(&Serial1), concurrency::OSThread("Serial") {}
 static Print *serialPrint = &Serial1;
@@ -54,369 +54,328 @@ uint32_t computeCrc32(const uint8_t *buf, uint16_t len)
 {
     uint32_t crc = 0xFFFFFFFF;        // Initial value
     const uint32_t poly = 0xEDB88320; // CRC-32 polynomial
-    uint32_t computeCrc32(const uint8_t *buf, uint16_t len)
-    {
-        uint32_t crc = 0xFFFFFFFF;        // Initial value
-        const uint32_t poly = 0xEDB88320; // CRC-32 polynomial
 
-        for (uint16_t i = 0; i < len; i++) {
-            crc ^= (uint8_t)buf[i];          // XOR with the current byte
-            for (int j = 7; j >= 0; j--) {   // Perform 8 bitwise operations
-                if (crc & 0x80000000) {      // Check if the MSB is set
-                    crc = (crc << 1) ^ poly; // Shift and XOR with polynomial
-                } else {
-                    crc <<= 1; // Shift if MSB is not set
-                }
-            }
-        }
-        return ~crc; // Return the final CRC value
-        for (uint16_t i = 0; i < len; i++) {
-            crc ^= (uint8_t)buf[i];          // XOR with the current byte
-            for (int j = 7; j >= 0; j--) {   // Perform 8 bitwise operations
-                if (crc & 0x80000000) {      // Check if the MSB is set
-                    crc = (crc << 1) ^ poly; // Shift and XOR with polynomial
-                } else {
-                    crc <<= 1; // Shift if MSB is not set
-                }
-            }
-        }
-        return ~crc; // Return the final CRC value
-    }
-
-    void meshPacketToSerialPacket(meshtastic_MeshPacket * p, meshtastic_serialPacket * sp)
-    {
-        sp->header.hbyte1 = headerByte1;
-        sp->header.hbyte2 = headerByte2;
-        sp->header.crc = 0;
-
-        if (p->which_payload_variant == meshtastic_MeshPacket_encrypted_tag) {
-            sp->header.size = sizeof(SerialPacketHeader) + p->encrypted.size;
-            memcpy(sp->payload, p->encrypted.bytes, p->encrypted.size);
-        } else {
-            sp->header.size = sizeof(SerialPacketHeader) + p->decoded.payload.size;
-            memcpy(sp->payload, p->decoded.payload.bytes, p->decoded.payload.size);
-        }
-        sp->header.from = p->from;
-        sp->header.to = p->to;
-        sp->header.id = p->id;
-        sp->header.channel = p->channel;
-
-        sp->header.hop_limit = p->hop_limit & PACKET_FLAGS_HOP_LIMIT_MASK;
-        sp->header.hop_start = p->hop_start & PACKET_FLAGS_HOP_START_MASK;
-        sp->header.flags = 0x20 | (p->want_ack ? PACKET_FLAGS_WANT_ACK_MASK : 0) |
-                           ((p->which_payload_variant == meshtastic_MeshPacket_encrypted_tag) ? PACKET_FLAGS_ENCRYPTED_MASK : 0);
-
-        sp->header.crc = computeCrc32((const uint8_t *)sp, sp->header.size);
-    }
-
-    void insertSerialPacketToMesh(meshtastic_serialPacket * sp)
-    {
-        void insertSerialPacketToMesh(meshtastic_serialPacket * sp)
-        {
-
-            UniquePacketPoolPacket p = packetPool.allocUniqueZeroed();
-
-            p->from = sp->header.from;
-            p->to = sp->header.to;
-            p->id = sp->header.id;
-            p->channel = sp->header.channel;
-            // assert(HOP_MAX <= PACKET_FLAGS_HOP_LIMIT_MASK); // If hopmax changes, carefully check this code
-            // assert(HOP_MAX <= PACKET_FLAGS_HOP_LIMIT_MASK); // If hopmax changes, carefully check this code
-            p->hop_limit = sp->header.hop_limit;
-            p->hop_start = sp->header.hop_start;
-            p->want_ack = !!(sp->header.flags & PACKET_FLAGS_WANT_ACK_MASK);
-            p->via_mqtt = 0;
-            uint16_t payloadLen = sp->header.size - sizeof(SerialPacketHeader);
-            if (!!(sp->header.flags & PACKET_FLAGS_ENCRYPTED_MASK)) {
-                p->which_payload_variant = meshtastic_MeshPacket_encrypted_tag;
-                memcpy(p->encrypted.bytes, sp->payload, payloadLen);
-                p->encrypted.size = payloadLen;
+    for (uint16_t i = 0; i < len; i++) {
+        crc ^= (uint8_t)buf[i];          // XOR with the current byte
+        for (int j = 7; j >= 0; j--) {   // Perform 8 bitwise operations
+            if (crc & 0x80000000) {      // Check if the MSB is set
+                crc = (crc << 1) ^ poly; // Shift and XOR with polynomial
             } else {
-                p->which_payload_variant = meshtastic_MeshPacket_decoded_tag;
-                memcpy(p->decoded.payload.bytes, sp->payload, payloadLen);
-                memcpy(p->decoded.payload.bytes, sp->payload, payloadLen);
-                p->decoded.payload.size = payloadLen;
+                crc <<= 1; // Shift if MSB is not set
             }
-
-            LOG_DEBUG("Serial Module RX  from=0x%0x, to=0x%0x, packet_id=0x%0x", p->from, p->to, p->id);
-            LOG_DEBUG("Serial Module RX  from=0x%0x, to=0x%0x, packet_id=0x%0x", p->from, p->to, p->id);
-
-            if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
-                memcpy(tmpbuf, p->decoded.payload.bytes, p->decoded.payload.size);
-                tmpbuf[p->decoded.payload.size + 1] = 0;
-                tmpbuf[p->decoded.payload.size + 1] = 0;
-                LOG_DEBUG("Serial Module RX packet of %d bytes, msg: %s", sp->header.size, tmpbuf);
-            }
-
-            router->enqueueReceivedMessage(p.release());
         }
+    }
+    return ~crc; // Return the final CRC value
+}
 
-        // check if this recieved serial packet is valid
-        bool checkIfValidPacket(meshtastic_serialPacket * sp)
-        {
-            bool checkIfValidPacket(meshtastic_serialPacket * sp)
-            {
+void meshPacketToSerialPacket(meshtastic_MeshPacket *p, meshtastic_serialPacket *sp)
+{
+    sp->header.hbyte1 = headerByte1;
+    sp->header.hbyte2 = headerByte2;
+    sp->header.crc = 0;
 
-                if (sp->header.hbyte1 != headerByte1 || sp->header.hbyte2 != headerByte2) {
-                    if (sp->header.hbyte1 != headerByte1 || sp->header.hbyte2 != headerByte2) {
-                        LOG_DEBUG("SerialModule:: valid packet check fail, header bytes");
-                        return false;
-                    }
-                    if (sp->header.size == 0 || sp->header.size > sizeof(meshtastic_serialPacket)) {
-                        LOG_DEBUG("SerialModule:: valid packet check fail, invalid size");
-                        return false;
-                    }
+    if (p->which_payload_variant == meshtastic_MeshPacket_encrypted_tag) {
+        sp->header.size = sizeof(SerialPacketHeader) + p->encrypted.size;
+        memcpy(sp->payload, p->encrypted.bytes, p->encrypted.size);
+    } else {
+        sp->header.size = sizeof(SerialPacketHeader) + p->decoded.payload.size;
+        memcpy(sp->payload, p->decoded.payload.bytes, p->decoded.payload.size);
+    }
+    sp->header.from = p->from;
+    sp->header.to = p->to;
+    sp->header.id = p->id;
+    sp->header.channel = p->channel;
 
-                    uint32_t received_crc = sp->header.crc;
-                    sp->header.crc = 0; // need to set to zero for computing CRC
-                    if (computeCrc32((const uint8_t *)sp, sp->header.size) != received_crc) {
-                        LOG_DEBUG("SerialModule:: valid packet check fail, invalid crc");
-                        sp->header.crc = received_crc; // restore
-                        return false;
-                    }
-                    sp->header.crc = received_crc; // restore
-                    return true;
+    sp->header.hop_limit = p->hop_limit & PACKET_FLAGS_HOP_LIMIT_MASK;
+    sp->header.hop_start = p->hop_start & PACKET_FLAGS_HOP_START_MASK;
+    sp->header.flags = 0x20 | (p->want_ack ? PACKET_FLAGS_WANT_ACK_MASK : 0) |
+                       ((p->which_payload_variant == meshtastic_MeshPacket_encrypted_tag) ? PACKET_FLAGS_ENCRYPTED_MASK : 0);
+
+    sp->header.crc = computeCrc32((const uint8_t *)sp, sp->header.size);
+}
+
+void insertSerialPacketToMesh(meshtastic_serialPacket *sp)
+{
+
+    UniquePacketPoolPacket p = packetPool.allocUniqueZeroed();
+
+    p->from = sp->header.from;
+    p->to = sp->header.to;
+    p->id = sp->header.id;
+    p->channel = sp->header.channel;
+    // assert(HOP_MAX <= PACKET_FLAGS_HOP_LIMIT_MASK); // If hopmax changes, carefully check this code
+    p->hop_limit = sp->header.hop_limit;
+    p->hop_start = sp->header.hop_start;
+    p->want_ack = !!(sp->header.flags & PACKET_FLAGS_WANT_ACK_MASK);
+    p->via_mqtt = 0;
+    uint16_t payloadLen = sp->header.size - sizeof(SerialPacketHeader);
+    if (!!(sp->header.flags & PACKET_FLAGS_ENCRYPTED_MASK)) {
+        p->which_payload_variant = meshtastic_MeshPacket_encrypted_tag;
+        memcpy(p->encrypted.bytes, sp->payload, payloadLen);
+        p->encrypted.size = payloadLen;
+    } else {
+        p->which_payload_variant = meshtastic_MeshPacket_decoded_tag;
+        memcpy(p->decoded.payload.bytes, sp->payload, payloadLen);
+        p->decoded.payload.size = payloadLen;
+    }
+
+    LOG_DEBUG("Serial Module RX  from=0x%0x, to=0x%0x, packet_id=0x%0x", p->from, p->to, p->id);
+
+    if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
+        memcpy(tmpbuf, p->decoded.payload.bytes, p->decoded.payload.size);
+        tmpbuf[p->decoded.payload.size + 1] = 0;
+        LOG_DEBUG("Serial Module RX packet of %d bytes, msg: %s", sp->header.size, tmpbuf);
+    }
+
+    router->enqueueReceivedMessage(p.release());
+}
+
+// check if this recieved serial packet is valid
+bool checkIfValidPacket(meshtastic_serialPacket *sp)
+{
+
+    if (sp->header.hbyte1 != headerByte1 || sp->header.hbyte2 != headerByte2) {
+        LOG_DEBUG("SerialModule:: valid packet check fail, header bytes");
+        return false;
+    }
+    if (sp->header.size == 0 || sp->header.size > sizeof(meshtastic_serialPacket)) {
+        LOG_DEBUG("SerialModule:: valid packet check fail, invalid size");
+        return false;
+    }
+
+    uint32_t received_crc = sp->header.crc;
+    sp->header.crc = 0; // need to set to zero for computing CRC
+    if (computeCrc32((const uint8_t *)sp, sp->header.size) != received_crc) {
+        LOG_DEBUG("SerialModule:: valid packet check fail, invalid crc");
+        sp->header.crc = received_crc; // restore
+        return false;
+    }
+    sp->header.crc = received_crc; // restore
+    return true;
+}
+
+SerialModuleRadio::SerialModuleRadio() : MeshModule("SerialModuleRadio")
+{
+    ourPortNum = meshtastic_PortNum_SERIAL_APP;
+}
+
+// define a simple verion of SerialModule that does not have all of the other crap in it
+// This is intended for the WisMesh starter kit + RS485 which uses Serial1
+//
+
+int32_t SerialModule::runOnce()
+{
+
+    moduleConfig.serial.enabled = true;
+    // These pins are RDX0, TXD0 on WisMesh Pocket. Cannot use this in production
+    // as the WisMesh pocket has a GPS on UART1, which clashes with the RS485 board
+    // moduleConfig.serial.rxd = 19;
+    // moduleConfig.serial.txd = 20;
+    // These next pins are RDX1, TXD1 on WishMesh  starter kit
+    // We would use these if using the WisMesh + RS485 interface
+    moduleConfig.serial.rxd = 15;
+    moduleConfig.serial.txd = 16;
+    moduleConfig.serial.override_console_serial_port = false;
+    moduleConfig.serial.mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_DEFAULT;
+    moduleConfig.serial.timeout = TIMEOUT;
+    moduleConfig.serial.echo = 0;
+    // No default, use value from config
+    // moduleConfig.serial.baud = meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_19200;
+
+    if (!moduleConfig.serial.enabled)
+        return disable();
+
+    if (firstTime) {
+        // Interface with the serial peripheral from in here.
+        LOG_INFO("Init serial peripheral interface");
+
+        uint32_t baud = getBaudRate();
+        Serial1.setPins(moduleConfig.serial.rxd, moduleConfig.serial.txd);
+        Serial1.begin(baud, SERIAL_8N1);
+        Serial1.setTimeout(moduleConfig.serial.timeout > 0 ? moduleConfig.serial.timeout : TIMEOUT);
+        serialModuleRadio = new SerialModuleRadio();
+        firstTime = 0;
+    } else {
+        int currentBufferCount = Serial1.available();
+        if (currentBufferCount) {
+            // data in the buffer.
+            if (lastBufferCount != currentBufferCount) {
+                // we have data, will wait until next poll to read it
+                // in case more data arrives
+                lastBufferCount = currentBufferCount;
+            } else {
+                // no data arrived since last poll, read this data
+                // read one packet
+                // stream.cpp/readBytes  arduinofruit library
+                serialPayloadSize = Serial1.readBytes((uint8_t *)&inPacket, sizeof(meshtastic_serialPacket));
+                if (!checkIfValidPacket(&inPacket)) {
+                    LOG_DEBUG("Serial Module failed CRC on RX, numbytes: %d", serialPayloadSize);
+                } else {
+                    // checks passed, pass this packet on
+                    LOG_DEBUG("Serial Module RX insert packet to mesh, numbytes: %d", serialPayloadSize);
+                    insertSerialPacketToMesh(&inPacket);
                 }
+                lastBufferCount = 0; // zero out the lastBuffer count
+            }
+        } else {
+            serialModuleRadio->checkTxQueue();
+        }
+    }
+    return (50);
+}
 
-                SerialModuleRadio::SerialModuleRadio() : MeshModule("SerialModuleRadio")
-                {
-                    ourPortNum = meshtastic_PortNum_SERIAL_APP;
-                }
+bool SerialModule::isValidConfig(const meshtastic_ModuleConfig_SerialConfig &config)
+{
+    return true;
+}
 
-                // define a simple verion of SerialModule that does not have all of the other crap in it
-                // This is intended for the WisMesh starter kit + RS485 which uses Serial1
-                //
-                //
+/**
+ * @brief Checks if the serial connection is established.
+ *
+ * @return true if the serial connection is established, false otherwise.
+ *
+ * For the serial2 port we can't really detect if any client is on the other side, so instead just look for recent messages
+ */
+bool SerialModule::checkIsConnected()
+{
+    // return Throttle::isWithinTimespanMs(lastContactMsec, SERIAL_CONNECTION_TIMEOUT);
+    //  we are not going to be able to determine if connected to another radio or not
+    //  just always return true
+    //  not sure where this function is called
+    return true;
+}
 
-                int32_t SerialModule::runOnce()
-                {
+/**
+ * Allocates a new mesh packet for use as a reply to a received packet.
+ *
+ * @return A pointer to the newly allocated mesh packet.
+ */
+meshtastic_MeshPacket *SerialModuleRadio::allocReply()
+{
+    auto reply = allocDataPacket(); // Allocate a packet for sending
 
-                    moduleConfig.serial.enabled = true;
-                    // These pins are RDX0, TXD0 on WisMesh Pocket. Cannot use this in production
-                    // as the WisMesh pocket has a GPS on UART1, which clashes with the RS485 board
-                    // moduleConfig.serial.rxd = 19;
-                    // moduleConfig.serial.txd = 20;
-                    // moduleConfig.serial.rxd = 19;
-                    // moduleConfig.serial.txd = 20;
-                    // These next pins are RDX1, TXD1 on WishMesh  starter kit
-                    // We would use these if using the WisMesh + RS485 interface
-                    moduleConfig.serial.rxd = 15;
-                    moduleConfig.serial.rxd = 15;
-                    moduleConfig.serial.txd = 16;
-                    moduleConfig.serial.override_console_serial_port = false;
-                    moduleConfig.serial.mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_DEFAULT;
-                    moduleConfig.serial.timeout = TIMEOUT;
-                    moduleConfig.serial.echo = 0;
-                    // No default, use value from config
-                    // moduleConfig.serial.baud = meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_19200;
-                    // No default, use value from config
-                    // moduleConfig.serial.baud = meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_19200;
+    return reply;
+}
 
-                    if (!moduleConfig.serial.enabled)
-                        return disable();
+bool SerialModuleRadio::wantPacket(const meshtastic_MeshPacket *p)
+{
+    // never accept packets from module handler as we are relying on sampling the RX input
+    return false;
+}
 
-                    if (firstTime) {
-                        // Interface with the serial peripheral from in here.
-                        LOG_INFO("Init serial peripheral interface");
+void SerialModuleRadio::sendPacketOverSerial(meshtastic_MeshPacket *p)
+{
+    meshPacketToSerialPacket(p, &outPacket);
+    // debug check
+    if (!checkIfValidPacket(&outPacket)) {
+        LOG_DEBUG("Serial Module failed CRC on TX");
+    } else {
+        if (Serial1.availableForWrite()) {
+            LOG_DEBUG("Serial Module onSend TX packet of %d bytes", outPacket.header.size);
+            Serial1.write((uint8_t *)&outPacket, outPacket.header.size);
+        }
+    }
+}
 
-                        uint32_t baud = getBaudRate();
-                        Serial1.setPins(moduleConfig.serial.rxd, moduleConfig.serial.txd);
-                        Serial1.begin(baud, SERIAL_8N1);
-                        Serial1.setTimeout(moduleConfig.serial.timeout > 0 ? moduleConfig.serial.timeout : TIMEOUT);
-                        serialModuleRadio = new SerialModuleRadio();
-                        firstTime = 0;
-                    } else {
-                        int currentBufferCount = Serial1.available();
-                        if (currentBufferCount) {
-                            // data in the buffer.
-                            if (lastBufferCount != currentBufferCount) {
-                                // we have data, will wait until next poll to read it
-                                // in case more data arrives
-                                lastBufferCount = currentBufferCount;
-                            } else {
-                                // no data arrived since last poll, read this data
-                                // read one packet
-                                // stream.cpp/readBytes  arduinofruit library
-                                serialPayloadSize = Serial1.readBytes((uint8_t *)&inPacket, sizeof(meshtastic_serialPacket));
-                                if (!checkIfValidPacket(&inPacket)) {
-                                    LOG_DEBUG("Serial Module failed CRC on RX, numbytes: %d", serialPayloadSize);
-                                } else {
-                                    // checks passed, pass this packet on
-                                    LOG_DEBUG("Serial Module RX insert packet to mesh, numbytes: %d", serialPayloadSize);
-                                    insertSerialPacketToMesh(&inPacket);
-                                }
-                                lastBufferCount = 0; // zero out the lastBuffer count
-                            }
-                        } else {
-                            serialModuleRadio->checkTxQueue();
-                        }
-                    }
-                    return (50);
-                }
+void SerialModuleRadio::checkTxQueue()
+{
+    if (txQueue.empty())
+        return; // nothing to do
+    meshtastic_MeshPacket *p = txQueue.dequeue();
+    LOG_DEBUG("Serial Module Onsend pulled packet from txQueue   from=0x%0x, to=0x%0x, packet_id=0x%0x", p->from, p->to, p->id);
+    LOG_DEBUG("Serial Module num in txQueue: %d", txQueue.getMaxLen() - txQueue.getFree());
+    sendPacketOverSerial(p);
+    // free this packet
+    packetPool.release(p);
+}
 
-                bool SerialModule::isValidConfig(const meshtastic_ModuleConfig_SerialConfig &config)
-                {
-                    return true;
-                }
+/*
+ Called from Router.cpp/Router::send
+ Send this over the link
+*/
+void SerialModuleRadio::onSend(meshtastic_MeshPacket *p)
+{
 
-                /**
-                 * @brief Checks if the serial connection is established.
-                 *
-                 * @return true if the serial connection is established, false otherwise.
-                 *
-                 * For the serial2 port we can't really detect if any client is on the other side, so instead just look for recent
-                 * messages
-                 */
-                bool SerialModule::checkIsConnected()
-                {
-                    // return Throttle::isWithinTimespanMs(lastContactMsec, SERIAL_CONNECTION_TIMEOUT);
-                    //  we are not going to be able to determine if connected to another radio or not
-                    //  just always return true
-                    //  not sure where this function is called
-                    return true;
-                    // return Throttle::isWithinTimespanMs(lastContactMsec, SERIAL_CONNECTION_TIMEOUT);
-                    //  we are not going to be able to determine if connected to another radio or not
-                    //  just always return true
-                    //  not sure where this function is called
-                    return true;
-                }
-
-                /**
-                 * Allocates a new mesh packet for use as a reply to a received packet.
-                 *
-                 * @return A pointer to the newly allocated mesh packet.
-                 */
-                meshtastic_MeshPacket *SerialModuleRadio::allocReply()
-                {
-                    auto reply = allocDataPacket(); // Allocate a packet for sending
-
-                    return reply;
-                }
-
-                bool SerialModuleRadio::wantPacket(const meshtastic_MeshPacket *p)
-                {
-                    bool SerialModuleRadio::wantPacket(const meshtastic_MeshPacket *p)
-                    {
-                        // never accept packets from module handler as we are relying on sampling the RX input
-                        return false;
-                    }
-
-                    void SerialModuleRadio::sendPacketOverSerial(meshtastic_MeshPacket * p)
-                    {
-                        meshPacketToSerialPacket(p, &outPacket);
-                        // debug check
-                        if (!checkIfValidPacket(&outPacket)) {
-                            LOG_DEBUG("Serial Module failed CRC on TX");
-                        } else {
-                            if (Serial1.availableForWrite()) {
-                                LOG_DEBUG("Serial Module onSend TX packet of %d bytes", outPacket.header.size);
-                                Serial1.write((uint8_t *)&outPacket, outPacket.header.size);
-                                Serial1.write((uint8_t *)&outPacket, outPacket.header.size);
-                            }
-                        }
-                    }
-
-                    void SerialModuleRadio::checkTxQueue()
-                    {
-                        if (txQueue.empty())
-                            return; // nothing to do
-                        meshtastic_MeshPacket *p = txQueue.dequeue();
-                        LOG_DEBUG("Serial Module Onsend pulled packet from txQueue   from=0x%0x, to=0x%0x, packet_id=0x%0x",
-                                  p->from, p->to, p->id);
-                        LOG_DEBUG("Serial Module num in txQueue: %d", txQueue.getMaxLen() - txQueue.getFree());
-                        sendPacketOverSerial(p);
-                        // free this packet
-                        packetPool.release(p);
-                    }
-
-                    /*
-                     Called from Router.cpp/Router::send
-                     Send this over the link
-                    */
-                    void SerialModuleRadio::onSend(meshtastic_MeshPacket * p)
-                    {
-
-                        LOG_DEBUG("Serial Module Onsend TX   from=0x%0x, to=0x%0x, packet_id=0x%0x", p->from, p->to, p->id);
+    LOG_DEBUG("Serial Module Onsend TX   from=0x%0x, to=0x%0x, packet_id=0x%0x", p->from, p->to, p->id);
 #ifndef FLAMINGO_DISABLE_SERIAL_TX_QUEUE
-                        // check if RX buffer has data
-                        if (Serial1.peek() != -1) {
-                            // there is data in the buffer, could be that RX is active
-                            // copy the packet. Need to enqueue
-                            bool dropped = false;
-                            meshtastic_MeshPacket *tosend = packetPool.allocCopy(*p);
-                            ErrorCode res = txQueue.enqueue(tosend, &dropped) ? ERRNO_OK : ERRNO_UNKNOWN;
+    // check if RX buffer has data
+    if (Serial1.peek() != -1) {
+        // there is data in the buffer, could be that RX is active
+        // copy the packet. Need to enqueue
+        bool dropped = false;
+        meshtastic_MeshPacket *tosend = packetPool.allocCopy(*p);
+        ErrorCode res = txQueue.enqueue(tosend, &dropped) ? ERRNO_OK : ERRNO_UNKNOWN;
 
-                            if (dropped) {
-                                txDrop++;
-                                LOG_DEBUG("Serial Module new drop, total dropped packets in txQueue: %d", txDrop);
-                            }
-                            if (res != ERRNO_OK) {
-                                // we weren't able to queue it, so we must drop it to prevent leaks
-                                // this packet was not sent
-                                LOG_DEBUG("Serial Module unable to send packet, txQueue error");
-                                packetPool.release(tosend);
-                            } else {
-                                LOG_DEBUG("Serial Module added packet to txQueue, num in txQueue: %d",
-                                          txQueue.getMaxLen() - txQueue.getFree());
-                            }
-                            return;
-                        }
+        if (dropped) {
+            txDrop++;
+            LOG_DEBUG("Serial Module new drop, total dropped packets in txQueue: %d", txDrop);
+        }
+        if (res != ERRNO_OK) {
+            // we weren't able to queue it, so we must drop it to prevent leaks
+            // this packet was not sent
+            LOG_DEBUG("Serial Module unable to send packet, txQueue error");
+            packetPool.release(tosend);
+        } else {
+            LOG_DEBUG("Serial Module added packet to txQueue, num in txQueue: %d", txQueue.getMaxLen() - txQueue.getFree());
+        }
+        return;
+    }
 #endif
-                        sendPacketOverSerial(p);
-                    }
+    sendPacketOverSerial(p);
+}
 
-                    /**
-                     * Handle a received mesh packet.
-                     *
-                     * @param mp The received mesh packet.
-                     * @return The processed message.
-                     */
-                    ProcessMessage SerialModuleRadio::handleReceived(const meshtastic_MeshPacket &mp)
-                    {
-                        // we are never going to handle packets when called from the Module handler
-                        return ProcessMessage::CONTINUE; // Let others look at this message also if they want
-                    }
+/**
+ * Handle a received mesh packet.
+ *
+ * @param mp The received mesh packet.
+ * @return The processed message.
+ */
+ProcessMessage SerialModuleRadio::handleReceived(const meshtastic_MeshPacket &mp)
+{
+    // we are never going to handle packets when called from the Module handler
+    return ProcessMessage::CONTINUE; // Let others look at this message also if they want
+}
 
-                    /**
-                     * @brief Returns the baud rate of the serial module from the module configuration.
-                     *
-                     * @return uint32_t The baud rate of the serial module.
-                     */
-                    uint32_t SerialModule::getBaudRate()
-                    {
-                        if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_110) {
-                            return 110;
-                        } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_300) {
-                            return 300;
-                        } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_600) {
-                            return 600;
-                        } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_1200) {
-                            return 1200;
-                        } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_2400) {
-                            return 2400;
-                        } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_4800) {
-                            return 4800;
-                        } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_9600) {
-                            return 9600;
-                        } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_19200) {
-                            return 19200;
-                        } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_38400) {
-                            return 38400;
-                        } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_57600) {
-                            return 57600;
-                        } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_115200) {
-                            return 115200;
-                        } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_230400) {
-                            return 230400;
-                        } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_460800) {
-                            return 460800;
-                        } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_576000) {
-                            return 576000;
-                        } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_921600) {
-                            return 921600;
-                        }
-                        return BAUD;
-                    }
+/**
+ * @brief Returns the baud rate of the serial module from the module configuration.
+ *
+ * @return uint32_t The baud rate of the serial module.
+ */
+uint32_t SerialModule::getBaudRate()
+{
+    if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_110) {
+        return 110;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_300) {
+        return 300;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_600) {
+        return 600;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_1200) {
+        return 1200;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_2400) {
+        return 2400;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_4800) {
+        return 4800;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_9600) {
+        return 9600;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_19200) {
+        return 19200;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_38400) {
+        return 38400;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_57600) {
+        return 57600;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_115200) {
+        return 115200;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_230400) {
+        return 230400;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_460800) {
+        return 460800;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_576000) {
+        return 576000;
+    } else if (moduleConfig.serial.baud == meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_921600) {
+        return 921600;
+    }
+    return BAUD;
+}
 
 #else
 

--- a/src/modules/SerialModule.cpp
+++ b/src/modules/SerialModule.cpp
@@ -15,7 +15,7 @@
 
     This module has been totally rewritten to function as a serial 'interface'
     for the router to send packets over the serial link similar to the MQTT interface.
-  
+
     The serial link is simply an alternate path for packets other than the air.
 
     This is not a module, it does not source new packets or sink packets
@@ -23,8 +23,6 @@
     This is intended for the WisMesh starter kit (19007 board+ 4630) + RS485 which uses Serial1
 
 */
-
-
 
 #define TIMEOUT 250
 #define BAUD 38400
@@ -40,9 +38,7 @@ SerialModuleRadio *serialModuleRadio;
 
 meshtastic_serialPacket outPacket;
 meshtastic_serialPacket inPacket;
-char tmpbuf[250];  // for debug only
-
-
+char tmpbuf[250]; // for debug only
 
 SerialModule::SerialModule() : StreamAPI(&Serial1), concurrency::OSThread("Serial") {}
 static Print *serialPrint = &Serial1;
@@ -50,54 +46,54 @@ static Print *serialPrint = &Serial1;
 #define headerByte1 0xaa
 #define headerByte2 0x55
 
-
 size_t serialPayloadSize;
 
-uint32_t computeCrc32(const uint8_t* buf, uint16_t len) {
-  uint32_t crc = 0xFFFFFFFF; // Initial value
-  const uint32_t poly = 0xEDB88320; // CRC-32 polynomial
+uint32_t computeCrc32(const uint8_t *buf, uint16_t len)
+{
+    uint32_t crc = 0xFFFFFFFF;        // Initial value
+    const uint32_t poly = 0xEDB88320; // CRC-32 polynomial
 
-  for (uint16_t i = 0; i < len; i++) {
-    crc ^= (uint8_t)buf[i]; // XOR with the current byte
-    for (int j = 7; j >= 0; j--) { // Perform 8 bitwise operations
-      if (crc & 0x80000000) { // Check if the MSB is set
-        crc = (crc << 1) ^ poly; // Shift and XOR with polynomial
-      } else {
-        crc <<= 1; // Shift if MSB is not set
-      }
+    for (uint16_t i = 0; i < len; i++) {
+        crc ^= (uint8_t)buf[i];          // XOR with the current byte
+        for (int j = 7; j >= 0; j--) {   // Perform 8 bitwise operations
+            if (crc & 0x80000000) {      // Check if the MSB is set
+                crc = (crc << 1) ^ poly; // Shift and XOR with polynomial
+            } else {
+                crc <<= 1; // Shift if MSB is not set
+            }
+        }
     }
-  }
-  return ~crc; // Return the final CRC value
+    return ~crc; // Return the final CRC value
 }
 
-
-
-void meshPacketToSerialPacket (const meshtastic_MeshPacket &mp, meshtastic_serialPacket *sp) {
+void meshPacketToSerialPacket(meshtastic_MeshPacket *p, meshtastic_serialPacket *sp)
+{
     sp->header.hbyte1 = headerByte1;
     sp->header.hbyte2 = headerByte2;
     sp->header.crc = 0;
-    
-    if (mp.which_payload_variant == meshtastic_MeshPacket_encrypted_tag ){
-        sp->header.size = sizeof(SerialPacketHeader) + mp.encrypted.size;
-        memcpy(sp->payload, mp.encrypted.bytes, mp.encrypted.size);
+
+    if (p->which_payload_variant == meshtastic_MeshPacket_encrypted_tag) {
+        sp->header.size = sizeof(SerialPacketHeader) + p->encrypted.size;
+        memcpy(sp->payload, p->encrypted.bytes, p->encrypted.size);
     } else {
-        sp->header.size = sizeof(SerialPacketHeader) + mp.decoded.payload.size;
-        memcpy(sp->payload, mp.decoded.payload.bytes, mp.decoded.payload.size);
+        sp->header.size = sizeof(SerialPacketHeader) + p->decoded.payload.size;
+        memcpy(sp->payload, p->decoded.payload.bytes, p->decoded.payload.size);
     }
-    sp->header.from = mp.from;
-    sp->header.to = mp.to;
-    sp->header.id = mp.id;
-    sp->header.channel = mp.channel;
-    
-    sp->header.hop_limit = mp.hop_limit & PACKET_FLAGS_HOP_LIMIT_MASK;
-    sp->header.hop_start = mp.hop_start & PACKET_FLAGS_HOP_START_MASK;
-    sp->header.flags =
-        0x20 | (mp.want_ack ? PACKET_FLAGS_WANT_ACK_MASK : 0) | ((mp.which_payload_variant == meshtastic_MeshPacket_encrypted_tag) ? PACKET_FLAGS_ENCRYPTED_MASK : 0);
+    sp->header.from = p->from;
+    sp->header.to = p->to;
+    sp->header.id = p->id;
+    sp->header.channel = p->channel;
+
+    sp->header.hop_limit = p->hop_limit & PACKET_FLAGS_HOP_LIMIT_MASK;
+    sp->header.hop_start = p->hop_start & PACKET_FLAGS_HOP_START_MASK;
+    sp->header.flags = 0x20 | (p->want_ack ? PACKET_FLAGS_WANT_ACK_MASK : 0) |
+                       ((p->which_payload_variant == meshtastic_MeshPacket_encrypted_tag) ? PACKET_FLAGS_ENCRYPTED_MASK : 0);
 
     sp->header.crc = computeCrc32((const uint8_t *)sp, sp->header.size);
 }
 
-void insertSerialPacketToMesh(meshtastic_serialPacket *sp) {
+void insertSerialPacketToMesh(meshtastic_serialPacket *sp)
+{
 
     UniquePacketPoolPacket p = packetPool.allocUniqueZeroed();
 
@@ -105,11 +101,10 @@ void insertSerialPacketToMesh(meshtastic_serialPacket *sp) {
     p->to = sp->header.to;
     p->id = sp->header.id;
     p->channel = sp->header.channel;
-    //assert(HOP_MAX <= PACKET_FLAGS_HOP_LIMIT_MASK); // If hopmax changes, carefully check this code
+    // assert(HOP_MAX <= PACKET_FLAGS_HOP_LIMIT_MASK); // If hopmax changes, carefully check this code
     p->hop_limit = sp->header.hop_limit;
     p->hop_start = sp->header.hop_start;
     p->want_ack = !!(sp->header.flags & PACKET_FLAGS_WANT_ACK_MASK);
-    p->via_slink = true;
     p->via_mqtt = 0;
     uint16_t payloadLen = sp->header.size - sizeof(SerialPacketHeader);
     if (!!(sp->header.flags & PACKET_FLAGS_ENCRYPTED_MASK)) {
@@ -118,30 +113,26 @@ void insertSerialPacketToMesh(meshtastic_serialPacket *sp) {
         p->encrypted.size = payloadLen;
     } else {
         p->which_payload_variant = meshtastic_MeshPacket_decoded_tag;
-        memcpy(p->decoded.payload.bytes, sp->payload,  payloadLen);
+        memcpy(p->decoded.payload.bytes, sp->payload, payloadLen);
         p->decoded.payload.size = payloadLen;
     }
 
-    LOG_DEBUG ("Serial Module RX  from=0x%0x, to=0x%0x, packet_id=0x%0x",
-              p->from, p->to, p->id);
+    LOG_DEBUG("Serial Module RX  from=0x%0x, to=0x%0x, packet_id=0x%0x", p->from, p->to, p->id);
 
     if (p->which_payload_variant == meshtastic_MeshPacket_decoded_tag) {
         memcpy(tmpbuf, p->decoded.payload.bytes, p->decoded.payload.size);
-        tmpbuf[p->decoded.payload.size+1]=0;
+        tmpbuf[p->decoded.payload.size + 1] = 0;
         LOG_DEBUG("Serial Module RX packet of %d bytes, msg: %s", sp->header.size, tmpbuf);
     }
-                    
-    router->enqueueReceivedMessage(p.release());
 
+    router->enqueueReceivedMessage(p.release());
 }
 
-
-
-
 // check if this recieved serial packet is valid
-bool checkIfValidPacket(meshtastic_serialPacket *sp) {
+bool checkIfValidPacket(meshtastic_serialPacket *sp)
+{
 
-    if (sp->header.hbyte1 != headerByte1 || sp->header.hbyte2 != headerByte2 ) {
+    if (sp->header.hbyte1 != headerByte1 || sp->header.hbyte2 != headerByte2) {
         LOG_DEBUG("SerialModule:: valid packet check fail, header bytes");
         return false;
     }
@@ -149,7 +140,7 @@ bool checkIfValidPacket(meshtastic_serialPacket *sp) {
         LOG_DEBUG("SerialModule:: valid packet check fail, invalid size");
         return false;
     }
-    
+
     uint32_t received_crc = sp->header.crc;
     sp->header.crc = 0; // need to set to zero for computing CRC
     if (computeCrc32((const uint8_t *)sp, sp->header.size) != received_crc) {
@@ -164,13 +155,11 @@ bool checkIfValidPacket(meshtastic_serialPacket *sp) {
 SerialModuleRadio::SerialModuleRadio() : MeshModule("SerialModuleRadio")
 {
     ourPortNum = meshtastic_PortNum_SERIAL_APP;
-    
 }
-
 
 // define a simple verion of SerialModule that does not have all of the other crap in it
 // This is intended for the WisMesh starter kit + RS485 which uses Serial1
-// 
+//
 
 int32_t SerialModule::runOnce()
 {
@@ -178,18 +167,18 @@ int32_t SerialModule::runOnce()
     moduleConfig.serial.enabled = true;
     // These pins are RDX0, TXD0 on WisMesh Pocket. Cannot use this in production
     // as the WisMesh pocket has a GPS on UART1, which clashes with the RS485 board
-    //moduleConfig.serial.rxd = 19;   
-    //moduleConfig.serial.txd = 20;
+    // moduleConfig.serial.rxd = 19;
+    // moduleConfig.serial.txd = 20;
     // These next pins are RDX1, TXD1 on WishMesh  starter kit
     // We would use these if using the WisMesh + RS485 interface
-    moduleConfig.serial.rxd = 15;   
+    moduleConfig.serial.rxd = 15;
     moduleConfig.serial.txd = 16;
     moduleConfig.serial.override_console_serial_port = false;
     moduleConfig.serial.mode = meshtastic_ModuleConfig_SerialConfig_Serial_Mode_DEFAULT;
     moduleConfig.serial.timeout = TIMEOUT;
     moduleConfig.serial.echo = 0;
-    //No default, use value from config
-    //moduleConfig.serial.baud = meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_19200;
+    // No default, use value from config
+    // moduleConfig.serial.baud = meshtastic_ModuleConfig_SerialConfig_Serial_Baud_BAUD_19200;
 
     if (!moduleConfig.serial.enabled)
         return disable();
@@ -205,18 +194,31 @@ int32_t SerialModule::runOnce()
         serialModuleRadio = new SerialModuleRadio();
         firstTime = 0;
     } else {
-            //stream.cpp/readBytes  arduinofruit library
-            while (Serial1.available()) {
-                serialPayloadSize = Serial1.readBytes((uint8_t *) &inPacket, sizeof(meshtastic_serialPacket));
-                 if (!checkIfValidPacket(&inPacket)) {
-                    LOG_DEBUG("Serial Module failed CRC on RX");
+        int currentBufferCount = Serial1.available();
+        if (currentBufferCount) {
+            // data in the buffer.
+            if (lastBufferCount != currentBufferCount) {
+                // we have data, will wait until next poll to read it
+                // in case more data arrives
+                lastBufferCount = currentBufferCount;
+            } else {
+                // no data arrived since last poll, read this data
+                // read one packet
+                // stream.cpp/readBytes  arduinofruit library
+                serialPayloadSize = Serial1.readBytes((uint8_t *)&inPacket, sizeof(meshtastic_serialPacket));
+                if (!checkIfValidPacket(&inPacket)) {
+                    LOG_DEBUG("Serial Module failed CRC on RX, numbytes: %d", serialPayloadSize);
                 } else {
                     // checks passed, pass this packet on
-                    LOG_DEBUG("Serial Module RX Insert packet to mesh");
+                    LOG_DEBUG("Serial Module RX insert packet to mesh, numbytes: %d", serialPayloadSize);
                     insertSerialPacketToMesh(&inPacket);
                 }
+                lastBufferCount = 0; // zero out the lastBuffer count
             }
+        } else {
+            serialModuleRadio->checkTxQueue();
         }
+    }
     return (50);
 }
 
@@ -234,13 +236,12 @@ bool SerialModule::isValidConfig(const meshtastic_ModuleConfig_SerialConfig &con
  */
 bool SerialModule::checkIsConnected()
 {
-    //return Throttle::isWithinTimespanMs(lastContactMsec, SERIAL_CONNECTION_TIMEOUT);
-    // we are not going to be able to determine if connected to another radio or not
-    // just always return true
-    // not sure where this function is called
-    return true;  
+    // return Throttle::isWithinTimespanMs(lastContactMsec, SERIAL_CONNECTION_TIMEOUT);
+    //  we are not going to be able to determine if connected to another radio or not
+    //  just always return true
+    //  not sure where this function is called
+    return true;
 }
-
 
 /**
  * Allocates a new mesh packet for use as a reply to a received packet.
@@ -254,34 +255,71 @@ meshtastic_MeshPacket *SerialModuleRadio::allocReply()
     return reply;
 }
 
-bool SerialModuleRadio::wantPacket(const meshtastic_MeshPacket *p) {
+bool SerialModuleRadio::wantPacket(const meshtastic_MeshPacket *p)
+{
     // never accept packets from module handler as we are relying on sampling the RX input
     return false;
 }
 
-/*
- Called from Router.cpp/Router::send
- Send this over the link
-*/
-void SerialModuleRadio::onSend(const meshtastic_MeshPacket &mp) {
-
-    if (mp.via_slink) {
-        LOG_DEBUG("Serial Module Onsend TX - ignoring packet that came from slink");
-    }
-    
-    LOG_DEBUG("Serial Module Onsend TX   from=0x%0x, to=0x%0x, packet_id=0x%0x",
-              mp.from, mp.to, mp.id);
-    meshPacketToSerialPacket(mp, &outPacket);
+void SerialModuleRadio::sendPacketOverSerial(meshtastic_MeshPacket *p)
+{
+    meshPacketToSerialPacket(p, &outPacket);
     // debug check
     if (!checkIfValidPacket(&outPacket)) {
         LOG_DEBUG("Serial Module failed CRC on TX");
     } else {
         if (Serial1.availableForWrite()) {
             LOG_DEBUG("Serial Module onSend TX packet of %d bytes", outPacket.header.size);
-            Serial1.write((uint8_t *) &outPacket, outPacket.header.size);
+            Serial1.write((uint8_t *)&outPacket, outPacket.header.size);
         }
     }
+}
 
+void SerialModuleRadio::checkTxQueue()
+{
+    if (txQueue.empty())
+        return; // nothing to do
+    meshtastic_MeshPacket *p = txQueue.dequeue();
+    LOG_DEBUG("Serial Module Onsend pulled packet from txQueue   from=0x%0x, to=0x%0x, packet_id=0x%0x", p->from, p->to, p->id);
+    LOG_DEBUG("Serial Module num in txQueue: %d", txQueue.getMaxLen() - txQueue.getFree());
+    sendPacketOverSerial(p);
+    // free this packet
+    packetPool.release(p);
+}
+
+/*
+ Called from Router.cpp/Router::send
+ Send this over the link
+*/
+void SerialModuleRadio::onSend(meshtastic_MeshPacket *p)
+{
+
+    LOG_DEBUG("Serial Module Onsend TX   from=0x%0x, to=0x%0x, packet_id=0x%0x", p->from, p->to, p->id);
+#ifndef FLAMINGO_DISABLE_SERIAL_TX_QUEUE
+    // check if RX buffer has data
+    if (Serial1.peek() != -1) {
+        // there is data in the buffer, could be that RX is active
+        // copy the packet. Need to enqueue
+        bool dropped = false;
+        meshtastic_MeshPacket *tosend = packetPool.allocCopy(*p);
+        ErrorCode res = txQueue.enqueue(tosend, &dropped) ? ERRNO_OK : ERRNO_UNKNOWN;
+
+        if (dropped) {
+            txDrop++;
+            LOG_DEBUG("Serial Module new drop, total dropped packets in txQueue: %d", txDrop);
+        }
+        if (res != ERRNO_OK) {
+            // we weren't able to queue it, so we must drop it to prevent leaks
+            // this packet was not sent
+            LOG_DEBUG("Serial Module unable to send packet, txQueue error");
+            packetPool.release(tosend);
+        } else {
+            LOG_DEBUG("Serial Module added packet to txQueue, num in txQueue: %d", txQueue.getMaxLen() - txQueue.getFree());
+        }
+        return;
+    }
+#endif
+    sendPacketOverSerial(p);
 }
 
 /**
@@ -339,13 +377,13 @@ uint32_t SerialModule::getBaudRate()
 
 #else
 
-#include "SerialModule.h"
 #include "GeoCoord.h"
 #include "MeshService.h"
 #include "NMEAWPL.h"
 #include "NodeDB.h"
 #include "RTC.h"
 #include "Router.h"
+#include "SerialModule.h"
 #include "configuration.h"
 #include <Arduino.h>
 #include <Throttle.h>

--- a/src/modules/SerialModule.h
+++ b/src/modules/SerialModule.h
@@ -3,6 +3,7 @@
 #if defined(FLAMINGO) && defined(FLAMINGO_SLINK)
 
 #include "MeshModule.h"
+#include "MeshPacketQueue.h"
 #include "Router.h"
 #include "SinglePortModule.h"
 #include "concurrency/OSThread.h"
@@ -10,16 +11,18 @@
 #include <Arduino.h>
 #include <functional>
 
+#define MAX_TX_SERIAL_QUEUE 8
+
 #if (defined(ARCH_ESP32) || defined(ARCH_NRF52) || defined(ARCH_RP2040)) && !defined(CONFIG_IDF_TARGET_ESP32S2) &&               \
     !defined(CONFIG_IDF_TARGET_ESP32C3)
 
-typedef struct _SerialPacketHeader{
+typedef struct _SerialPacketHeader {
     uint8_t hbyte1;
     uint8_t hbyte2;
-    uint16_t size;  //this is size of header + payload length
+    uint16_t size; // this is size of header + payload length
     uint32_t crc;
     NodeNum to, from; // can be 1 byte or four bytes
-    PacketId id; // can be 1 byte or 4 bytes
+    PacketId id;      // can be 1 byte or 4 bytes
 
     /**
      * Usage of flags:
@@ -31,26 +34,23 @@ typedef struct _SerialPacketHeader{
     /** The channel hash - used as a hint for the decoder to limit which channels we consider */
     uint8_t channel;
 
-    uint8_t hop_limit;   // new place for hop_limit
+    uint8_t hop_limit; // new place for hop_limit
 
-    uint8_t hop_start;   // new place for hop_start
+    uint8_t hop_start; // new place for hop_start
 
-    
 } SerialPacketHeader;
 
-
-typedef struct _meshtastic_serialPacket{
+typedef struct _meshtastic_serialPacket {
     SerialPacketHeader header;
-    uint8_t payload[256];    // 256 is max payload size
+    uint8_t payload[256]; // 256 is max payload size
 } meshtastic_serialPacket;
-
-
 
 class SerialModule : public StreamAPI, private concurrency::OSThread
 {
     bool firstTime = 1;
     unsigned long lastNmeaTime = millis();
     char outbuf[90] = "";
+    int lastBufferCount = 0;
 
   public:
     SerialModule();
@@ -61,10 +61,9 @@ class SerialModule : public StreamAPI, private concurrency::OSThread
 
     /// Check the current underlying physical link to see if the client is currently connected
     virtual bool checkIsConnected() override;
-   
+
   private:
     uint32_t getBaudRate();
-    
 };
 
 extern SerialModule *serialModule;
@@ -76,14 +75,13 @@ extern SerialModule *serialModule;
 class SerialModuleRadio : public MeshModule
 {
     uint32_t lastRxID = 0;
-   
-
+    uint16_t txDrop = 0;
+    MeshPacketQueue txQueue = MeshPacketQueue(MAX_TX_SERIAL_QUEUE);
 
   public:
     SerialModuleRadio();
-    void onSend(const meshtastic_MeshPacket &mp);
-    
-
+    void onSend(meshtastic_MeshPacket *p);
+    void checkTxQueue();
 
   protected:
     virtual meshtastic_MeshPacket *allocReply() override;
@@ -97,7 +95,7 @@ class SerialModuleRadio : public MeshModule
 
     meshtastic_PortNum ourPortNum;
 
-    //virtual bool wantPacket(const meshtastic_MeshPacket *p) override { return p->decoded.portnum == ourPortNum; }
+    // virtual bool wantPacket(const meshtastic_MeshPacket *p) override { return p->decoded.portnum == ourPortNum; }
     virtual bool wantPacket(const meshtastic_MeshPacket *p) override;
 
     meshtastic_MeshPacket *allocDataPacket()
@@ -108,6 +106,9 @@ class SerialModuleRadio : public MeshModule
 
         return p;
     }
+
+  private:
+    void sendPacketOverSerial(meshtastic_MeshPacket *p);
 };
 
 extern SerialModuleRadio *serialModuleRadio;

--- a/variants/nrf52840/rak4631/platformio.ini
+++ b/variants/nrf52840/rak4631/platformio.ini
@@ -112,7 +112,25 @@ lib_deps =
 upload_protocol = stlink
 
 
+; cave node generation 2 with hop_debug
+; Forces nodes to accept only neighbor packets
+; based on node name
 
+[env:rak4631_cavegen2_hopdebug]
+extends = env:rak4631_cavegen2
+board_level = extra
+
+build_flags =
+  ${env:rak4631_cavegen2.build_flags}
+  -D FLAMINGO_HOP_DEBUG
+  -DFLAMINGO_REJECT_PERCENTAGE=50
+  
+
+lib_deps =
+  ${env:rak4631_cavegen2.lib_deps}
+  
+
+upload_protocol = stlink
 
 
 ; If not set we will default to uploading over serial (first it forces bootloader entry by talking 1200bps to cdcacm)

--- a/variants/nrf52840/rak4631/platformio.ini
+++ b/variants/nrf52840/rak4631/platformio.ini
@@ -32,12 +32,18 @@ upload_protocol = stlink
 ;upload_protocol = jlink
 ;debug_tool = jlink
 
+; FLAMINGO_MAX_RXMIT controls number of retransmits for both broadcast packets (flooding router)
+; and direct messages (next hop router).
+; If 0, then no rexmits for either one.
+; If not defined, code reverts to stock firmware behavior.
+
 build_flags =
   ${env:rak4631.build_flags}
   -D USE_SEMIHOSTING
   -D FLAMINGO
   -D MESHTASTIC_EXCLUDE_MQTT
-  -DUSERPREFS_SPLASH_TITLE=\"FLAMINGO.11.25\"
+  -DUSERPREFS_SPLASH_TITLE=\"FLAMINGO.1.26\"
+  -DFLAMINGO_MAX_REXMIT=2
 ;-D FLAMINGO_SLINK_DEBUG
 ;-D MESHTASTIC_EXCLUDE_GPS
 ;-D LORA_DISABLE_SENDING


### PR DESCRIPTION
I noticed when looking at the flamingo branch in the base repo that none of the changes for channel packet rebroadcast made it into the branch.  

This PR has the channel packet rebroadcast changes as well as the new serial code that has TX queue.  This would bring the flamingo branch up to date with all of my changes.



## 🤝 Attestations

- [ ] I have tested that my proposed changes behave as described.
- [ ] I have tested that my proposed changes do not cause any obvious regressions on the following devices:
  - [ ] Heltec (Lora32) V3
  - [ ] LilyGo T-Deck
  - [ ] LilyGo T-Beam
  - [ ] RAK WisBlock 4631
  - [ ] Seeed Studio T-1000E tracker card
  - [ ] Other (please specify below)
