### PR TITLE
Repo/autobuild release

### DIFF
--- a/.github/workflows/autobuild_flamingo_targets.yml
+++ b/.github/workflows/autobuild_flamingo_targets.yml
@@ -3,7 +3,7 @@ name: Autobuild Flamingo Targets
 on:
   push:
     branches: [autobuilds]
-    tags: ["flamingo*"]
+    tags: [flamingo*]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/autobuild_flamingo_targets.yml
+++ b/.github/workflows/autobuild_flamingo_targets.yml
@@ -1,0 +1,47 @@
+name: Autobuild Flamingo Targets
+
+on:
+  push:
+    branches: [autobuilds]
+  workflow_dispatch:
+
+concurrency:
+  group: build-autobuilds-targets-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Get release version string
+        run: |
+          echo "long=$(./bin/buildinfo.py long)" >> $GITHUB_OUTPUT
+          echo "deb=$(./bin/buildinfo.py deb)" >> $GITHUB_OUTPUT
+        id: version
+        env:
+          BUILD_LOCATION: local
+    outputs:
+      long: ${{ steps.version.outputs.long }}
+      deb: ${{ steps.version.outputs.deb }}
+
+  build:
+    name: build-${{ matrix.target }}
+    needs: [version]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: nswcrs
+            platform: nrf52840
+          - target: nswcrs_flamingo
+            platform: nrf52840
+          # - target: heltec-v3_flamingo
+          #   platform: esp32s3
+    uses: ./.github/workflows/build_firmware.yml
+    with:
+      version: ${{ needs.version.outputs.long }}
+      platform: ${{ matrix.platform }}
+      pio_env: ${{ matrix.target }}

--- a/.github/workflows/autobuild_flamingo_targets.yml
+++ b/.github/workflows/autobuild_flamingo_targets.yml
@@ -35,12 +35,35 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - target: heltec-mesh-node-t114_flamingo
+            platform: nrf52840
           - target: nswcrs
             platform: nrf52840
           - target: nswcrs_flamingo
             platform: nrf52840
-          # - target: heltec-v3_flamingo
-          #   platform: esp32s3
+          - target: nswcrs_flamingo_slink
+            platform: nrf52840
+          - target: rak4631_flamingo
+            platform: nrf52840
+          - target: rak4631_slink
+            platform: nrf52840
+          - target: rak4631_buzzer
+            platform: nrf52840
+          - target: rak4631_cavegen2
+            platform: nrf52840
+          - target: rak_wismeshtag_flamingo
+            platform: nrf52840
+          # - target: seeed_xiao_nrf52840_kit_flamingo
+          #   platform: nrf52840
+          - target: seeed_xiao_nrf52840_sense_flamingo
+            platform: nrf52840
+          - target: tracker-t1000-e_flamingo
+            platform: nrf52840
+          - target: heltec-v3_flamingo
+            platform: esp32s3
+          - target: t-deck-tft_flamingo
+            platform: esp32s3
+
     uses: ./.github/workflows/build_firmware.yml
     with:
       version: ${{ needs.version.outputs.long }}

--- a/.github/workflows/autobuild_flamingo_targets.yml
+++ b/.github/workflows/autobuild_flamingo_targets.yml
@@ -3,6 +3,7 @@ name: Autobuild Flamingo Targets
 on:
   push:
     branches: [autobuilds]
+    tags: ["flamingo*"]
   workflow_dispatch:
 
 concurrency:
@@ -45,3 +46,35 @@ jobs:
       version: ${{ needs.version.outputs.long }}
       platform: ${{ matrix.platform }}
       pio_env: ${{ matrix.target }}
+
+  release:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs: [version, build]
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: firmware-*-${{ needs.version.outputs.long }}
+          path: ./artifacts
+          merge-multiple: false
+
+      - name: Zip each target for release
+        run: |
+          for d in ./artifacts/firmware-*/; do
+            n=$(basename "$d")
+            zip -j -r "./${n}.zip" "$d"
+          done
+
+      - name: Create release and upload assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Flamingo ${{ github.ref_name }}
+          body: "Autobuild Flamingo firmware ${{ github.ref_name }}"
+          files: firmware-*.zip
+          draft: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Set up auto builds using the build one target. 
   -  Can run manually, or automatically on an 'autorun' branch. 
   - will run and create a release on a tag starting with 'flamingo' 

It will use 50 ish minutes of compute on every tag, so keep them a bit limited. 
(Rob, if we can drop any of your targets from the automatic list, let me know)

Release pipeline 
https://github.com/DaneEvans/Flamingo-Firmware/actions/runs/21285248664
(I deleted the release afterwards. )

Autobuild branch 
https://github.com/DaneEvans/Flamingo-Firmware/actions/runs/21285199198

## 🤝 Attestations

- [x] I have tested that my proposed changes behave as described.
