### PR TITLE
changes firmware variant to make it easier to tell if you're on stock vs flamingo.

### DIFF
--- a/userPrefs.jsonc
+++ b/userPrefs.jsonc
@@ -23,7 +23,7 @@
   // "USERPREFS_CONFIG_OWNER_SHORT_NAME": "MLN",
   // "USERPREFS_CONFIG_DEVICE_ROLE": "meshtastic_Config_DeviceConfig_Role_CLIENT", // Defaults to CLIENT. ROUTER*, and LOST AND FOUND roles are restricted.
   // "USERPREFS_EVENT_MODE": "1",
-  // "USERPREFS_FIRMWARE_EDITION": "meshtastic_FirmwareEdition_BURNING_MAN",
+  "USERPREFS_FIRMWARE_EDITION": "meshtastic_FirmwareEdition_DIY_EDITION",
   // "USERPREFS_FIXED_BLUETOOTH": "121212",
   // "USERPREFS_FIXED_GPS": "",
   // "USERPREFS_FIXED_GPS_ALT": "0",


### PR DESCRIPTION
… vs flamingo.

- visible on cli.
- supposedly it's noticible on android (I think it's an icecream emoji next to the firmware info if you're on vanilla, but I haven't got anything to test at the moment
