### PR TITLE
auto builds of non-flamingo should now appear as 'vanilla'

### DIFF
--- a/.github/workflows/autobuild_flamingo_targets.yml
+++ b/.github/workflows/autobuild_flamingo_targets.yml
@@ -39,6 +39,7 @@ jobs:
             platform: nrf52840
           - target: nswcrs
             platform: nrf52840
+            is_vanilla: true
           - target: nswcrs_flamingo
             platform: nrf52840
           - target: nswcrs_flamingo_slink
@@ -74,6 +75,7 @@ jobs:
       version: ${{ needs.version.outputs.long }}
       platform: ${{ matrix.platform }}
       pio_env: ${{ matrix.target }}
+      is_vanilla: ${{ matrix.is_vanilla == true }}
 
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -12,6 +12,10 @@ on:
       pio_env:
         required: true
         type: string
+      is_vanilla:
+        required: false
+        type: boolean
+        default: false
 
 permissions: read-all
 
@@ -45,6 +49,12 @@ jobs:
             echo "src=firmware.bin" >> $GITHUB_OUTPUT
             echo "tgt=release/bleota.bin" >> $GITHUB_OUTPUT
           fi
+
+      # Build as vanilla when requested by caller.
+      - name: Disable firmware edition override
+        if: ${{ inputs.is_vanilla }}
+        run: |
+          sed -i -E 's/^([[:space:]]*)"USERPREFS_FIRMWARE_EDITION":/\1\/\/ "USERPREFS_FIRMWARE_EDITION":/' userPrefs.jsonc
 
       - name: Build ${{ inputs.platform }}
         id: build

--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -96,27 +96,17 @@ jobs:
         run: |
           echo "[manifest] pio_env=$PIO_ENV"
           echo "[manifest] workspace=$(pwd)"
-          ls -la release/firmware-*.mt.json
-          python3 - <<'PY'
-import glob
-import json
-
-paths = sorted(glob.glob("release/firmware-*.mt.json"))
-if not paths:
-    raise SystemExit("No release/firmware-*.mt.json files found")
-
-for path in paths:
-    with open(path, "r", encoding="utf-8") as handle:
-        data = json.load(handle)
-
-    firmware_edition = data.get("firmware_edition")
-    if firmware_edition is None and isinstance(data.get("metadata"), dict):
-        firmware_edition = data["metadata"].get("firmware_edition")
-    if firmware_edition is None and isinstance(data.get("device_metadata"), dict):
-        firmware_edition = data["device_metadata"].get("firmware_edition")
-
-    print(f"[manifest] {path}: firmware_edition={firmware_edition}")
-PY
+          shopt -s nullglob
+          files=(release/firmware-*.mt.json)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "[manifest] no release/firmware-*.mt.json files found"
+            exit 1
+          fi
+          ls -la "${files[@]}"
+          for path in "${files[@]}"; do
+            echo "[manifest] $path"
+            grep -nE '"firmware_edition"[[:space:]]*:' "$path" || echo "[manifest] firmware_edition key not found in $path"
+          done
 
       - name: Job summary
         env:

--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -52,33 +52,11 @@ jobs:
 
       # Build as vanilla when requested by caller.
       - name: Set firmware edition to VANILLA
-        id: vanilla_prefs
         if: ${{ inputs.is_vanilla }}
-        env:
-          PIO_ENV: ${{ inputs.pio_env }}
         run: |
-          echo "[vanilla] pio_env=$PIO_ENV"
-          echo "[vanilla] workspace=$(pwd)"
-          echo "[vanilla] before change:"
-          grep -n 'USERPREFS_FIRMWARE_EDITION' userPrefs.jsonc || true
-
           sed -i -E 's|^([[:space:]]*)//[[:space:]]*"USERPREFS_FIRMWARE_EDITION"[[:space:]]*:[[:space:]]*"[^"]*"[[:space:]]*,[[:space:]]*$|\1"USERPREFS_FIRMWARE_EDITION": "meshtastic_FirmwareEdition_VANILLA",|' userPrefs.jsonc
           sed -i -E 's|^([[:space:]]*)"USERPREFS_FIRMWARE_EDITION"[[:space:]]*:[[:space:]]*"[^"]*"[[:space:]]*,[[:space:]]*$|\1"USERPREFS_FIRMWARE_EDITION": "meshtastic_FirmwareEdition_VANILLA",|' userPrefs.jsonc
           grep -q '"USERPREFS_FIRMWARE_EDITION": "meshtastic_FirmwareEdition_VANILLA"' userPrefs.jsonc
-
-          echo "[vanilla] after change:"
-          grep -n 'USERPREFS_FIRMWARE_EDITION' userPrefs.jsonc || true
-          sha256sum userPrefs.jsonc
-
-      - name: Verify vanilla prefs before build
-        if: ${{ inputs.is_vanilla }}
-        env:
-          PIO_ENV: ${{ inputs.pio_env }}
-        run: |
-          echo "[vanilla] verifying before build for pio_env=$PIO_ENV"
-          echo "[vanilla] workspace=$(pwd)"
-          grep -n 'USERPREFS_FIRMWARE_EDITION' userPrefs.jsonc || true
-          sha256sum userPrefs.jsonc
 
       - name: Build ${{ inputs.platform }}
         id: build
@@ -89,24 +67,6 @@ jobs:
           pio_target: build
           ota_firmware_source: ${{ steps.ota_dir.outputs.src || '' }}
           ota_firmware_target: ${{ steps.ota_dir.outputs.tgt || '' }}
-
-      - name: Log final firmware edition from manifest
-        env:
-          PIO_ENV: ${{ inputs.pio_env }}
-        run: |
-          echo "[manifest] pio_env=$PIO_ENV"
-          echo "[manifest] workspace=$(pwd)"
-          shopt -s nullglob
-          files=(release/firmware-*.mt.json)
-          if [ ${#files[@]} -eq 0 ]; then
-            echo "[manifest] no release/firmware-*.mt.json files found"
-            exit 1
-          fi
-          ls -la "${files[@]}"
-          for path in "${files[@]}"; do
-            echo "[manifest] $path"
-            grep -nE '"firmware_edition"[[:space:]]*:' "$path" || echo "[manifest] firmware_edition key not found in $path"
-          done
 
       - name: Job summary
         env:

--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -62,20 +62,9 @@ jobs:
           echo "[vanilla] before change:"
           grep -n 'USERPREFS_FIRMWARE_EDITION' userPrefs.jsonc || true
 
-          python3 - <<'PY'
-import pathlib
-import re
-
-path = pathlib.Path("userPrefs.jsonc")
-text = path.read_text(encoding="utf-8")
-replacement = '  "USERPREFS_FIRMWARE_EDITION": "meshtastic_FirmwareEdition_VANILLA",'
-pattern = re.compile(r'^\s*(?://\s*)?"USERPREFS_FIRMWARE_EDITION"\s*:\s*"[^"]*"\s*,\s*$', re.MULTILINE)
-new_text, count = pattern.subn(replacement, text, count=1)
-if count == 0:
-    raise SystemExit("USERPREFS_FIRMWARE_EDITION not found in userPrefs.jsonc")
-path.write_text(new_text, encoding="utf-8")
-print("Updated USERPREFS_FIRMWARE_EDITION to VANILLA")
-PY
+          sed -i -E 's|^([[:space:]]*)//[[:space:]]*"USERPREFS_FIRMWARE_EDITION"[[:space:]]*:[[:space:]]*"[^"]*"[[:space:]]*,[[:space:]]*$|\1"USERPREFS_FIRMWARE_EDITION": "meshtastic_FirmwareEdition_VANILLA",|' userPrefs.jsonc
+          sed -i -E 's|^([[:space:]]*)"USERPREFS_FIRMWARE_EDITION"[[:space:]]*:[[:space:]]*"[^"]*"[[:space:]]*,[[:space:]]*$|\1"USERPREFS_FIRMWARE_EDITION": "meshtastic_FirmwareEdition_VANILLA",|' userPrefs.jsonc
+          grep -q '"USERPREFS_FIRMWARE_EDITION": "meshtastic_FirmwareEdition_VANILLA"' userPrefs.jsonc
 
           echo "[vanilla] after change:"
           grep -n 'USERPREFS_FIRMWARE_EDITION' userPrefs.jsonc || true
@@ -100,6 +89,34 @@ PY
           pio_target: build
           ota_firmware_source: ${{ steps.ota_dir.outputs.src || '' }}
           ota_firmware_target: ${{ steps.ota_dir.outputs.tgt || '' }}
+
+      - name: Log final firmware edition from manifest
+        env:
+          PIO_ENV: ${{ inputs.pio_env }}
+        run: |
+          echo "[manifest] pio_env=$PIO_ENV"
+          echo "[manifest] workspace=$(pwd)"
+          ls -la release/firmware-*.mt.json
+          python3 - <<'PY'
+import glob
+import json
+
+paths = sorted(glob.glob("release/firmware-*.mt.json"))
+if not paths:
+    raise SystemExit("No release/firmware-*.mt.json files found")
+
+for path in paths:
+    with open(path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+
+    firmware_edition = data.get("firmware_edition")
+    if firmware_edition is None and isinstance(data.get("metadata"), dict):
+        firmware_edition = data["metadata"].get("firmware_edition")
+    if firmware_edition is None and isinstance(data.get("device_metadata"), dict):
+        firmware_edition = data["device_metadata"].get("firmware_edition")
+
+    print(f"[manifest] {path}: firmware_edition={firmware_edition}")
+PY
 
       - name: Job summary
         env:

--- a/.github/workflows/build_firmware.yml
+++ b/.github/workflows/build_firmware.yml
@@ -51,10 +51,45 @@ jobs:
           fi
 
       # Build as vanilla when requested by caller.
-      - name: Disable firmware edition override
+      - name: Set firmware edition to VANILLA
+        id: vanilla_prefs
         if: ${{ inputs.is_vanilla }}
+        env:
+          PIO_ENV: ${{ inputs.pio_env }}
         run: |
-          sed -i -E 's/^([[:space:]]*)"USERPREFS_FIRMWARE_EDITION":/\1\/\/ "USERPREFS_FIRMWARE_EDITION":/' userPrefs.jsonc
+          echo "[vanilla] pio_env=$PIO_ENV"
+          echo "[vanilla] workspace=$(pwd)"
+          echo "[vanilla] before change:"
+          grep -n 'USERPREFS_FIRMWARE_EDITION' userPrefs.jsonc || true
+
+          python3 - <<'PY'
+import pathlib
+import re
+
+path = pathlib.Path("userPrefs.jsonc")
+text = path.read_text(encoding="utf-8")
+replacement = '  "USERPREFS_FIRMWARE_EDITION": "meshtastic_FirmwareEdition_VANILLA",'
+pattern = re.compile(r'^\s*(?://\s*)?"USERPREFS_FIRMWARE_EDITION"\s*:\s*"[^"]*"\s*,\s*$', re.MULTILINE)
+new_text, count = pattern.subn(replacement, text, count=1)
+if count == 0:
+    raise SystemExit("USERPREFS_FIRMWARE_EDITION not found in userPrefs.jsonc")
+path.write_text(new_text, encoding="utf-8")
+print("Updated USERPREFS_FIRMWARE_EDITION to VANILLA")
+PY
+
+          echo "[vanilla] after change:"
+          grep -n 'USERPREFS_FIRMWARE_EDITION' userPrefs.jsonc || true
+          sha256sum userPrefs.jsonc
+
+      - name: Verify vanilla prefs before build
+        if: ${{ inputs.is_vanilla }}
+        env:
+          PIO_ENV: ${{ inputs.pio_env }}
+        run: |
+          echo "[vanilla] verifying before build for pio_env=$PIO_ENV"
+          echo "[vanilla] workspace=$(pwd)"
+          grep -n 'USERPREFS_FIRMWARE_EDITION' userPrefs.jsonc || true
+          sha256sum userPrefs.jsonc
 
       - name: Build ${{ inputs.platform }}
         id: build


### PR DESCRIPTION
Needs testing as it's merged 
Theoretically, it means that the nswcrs variant will display as vanilla, while the others display as custom. 
